### PR TITLE
Network/packet serilization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SOURCES
         network/Network.cpp
         network/Socket.cpp
         network/protocol/PacketSerialization.cpp
+        network/protocol/Packet.cpp
+        network/protocol/PacketCodec.cpp
 )
 
 set(HEADERS
@@ -27,6 +29,8 @@ set(HEADERS
         network/Network.h
         network/Socket.h
         network/protocol/PacketSerialization.h
+        network/protocol/Packet.h
+        network/protocol/PacketCodec.h
 )
 
 # Project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,16 +16,17 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
 
 # Source files
 set(SOURCES
-        Stratos.cpp
         Server.cpp
         network/Network.cpp
         network/Socket.cpp
+        network/protocol/PacketSerialization.cpp
 )
 
 set(HEADERS
         Server.h
         network/Network.h
         network/Socket.h
+        network/protocol/PacketSerialization.h
 )
 
 # Project
@@ -43,10 +44,36 @@ target_include_directories(${LOCAL_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
         ${CMAKE_CURRENT_SOURCE_DIR}/vendor/spdlog/include
         ${CMAKE_CURRENT_SOURCE_DIR}/vendor/concurrentqueue
 )
-target_sources(${LOCAL_PROJECT_NAME} PRIVATE ${SOURCES} ${HEADERS})
+target_sources(${LOCAL_PROJECT_NAME} PRIVATE src/Stratos.cpp ${SOURCES} ${HEADERS})
 
 if (WIN32)
     target_link_libraries(Stratos PRIVATE iphlpapi ws2_32)
 endif ()
 
 set_target_properties(${LOCAL_PROJECT_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "bin")
+
+# Testing
+enable_testing()
+
+add_executable("${LOCAL_PROJECT_NAME}Test" test/stratos_test.cpp)
+
+target_include_directories("${LOCAL_PROJECT_NAME}Test" PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_include_directories("${LOCAL_PROJECT_NAME}Test" PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/vendor/spdlog/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/vendor/concurrentqueue
+)
+target_sources("${LOCAL_PROJECT_NAME}Test" PRIVATE
+        ${SOURCES}
+        ${HEADERS}
+)
+
+if (WIN32)
+    target_link_libraries("${LOCAL_PROJECT_NAME}Test" PRIVATE iphlpapi ws2_32)
+endif()
+
+set_target_properties("${LOCAL_PROJECT_NAME}Test" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "bin")
+
+add_test(NAME NetworkSerialization COMMAND "${LOCAL_PROJECT_NAME}Test" --network-serialization)

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -21,6 +21,7 @@
 
 #include "spdlog/logger.h"
 
+#include <queue>
 #include <ranges>
 #ifdef __linux__
 #include <sys/epoll.h>
@@ -61,8 +62,10 @@ void stratos::NetworkSession::handleClientHandshake(const ClientHandshake& packe
         protocolState = Status;
 }
 void stratos::NetworkSession::handleStatusRequest() const {
-    if (protocolState == Status)
-        send(StatusResponse("{\"version\":{\"name\":\"1.21.5\",\"protocol\":770},\"players\":{\"max\":20,\"online\":0,\"sample\":[]},\"description\":{\"text\":\"A Minecraft Server\"}}"));
+    if (protocolState == Status) {
+        send(StatusResponse(
+            R"({"version":{"name":"1.21.5","protocol":770},"players":{"max":20,"online":0,"sample":[]},"description":{"text":"A Minecraft Server"}})"));
+    }
 }
 void stratos::NetworkSession::handlePingRequest(const int64_t timestamp) const {
     if (protocolState == Status)
@@ -76,17 +79,6 @@ void stratos::NetworkSession::processReceived() {
     }
 }
 void stratos::NetworkSession::handleRawReceived() {
-    // std::cout << "Handling raw received data (" << recvBuffer.size() << ")for client " << sessionId.ip << ":" << sessionId.port << ": ";
-    // for (int i = 0; i < recvBuffer.size(); ++i) {
-    //     printf("%02X ", recvBuffer.data()[i]);
-    // }
-    // std::cout << "  |  ";
-    // for (size_t i = 0; i < recvBuffer.size(); ++i) {
-    //     const char c = (std::isprint(recvBuffer.data()[i]) ? recvBuffer.data()[i] : '.');
-    //     std::cout << c;
-    // }
-    // std::cout << std::endl;
-
     size_t offset = 0;
     while (recvBuffer.size() > 0) {
         if (protocolState == Handshaking) {
@@ -124,7 +116,7 @@ void stratos::NetworkSession::handleRawReceived() {
                     return;
                 }
 
-                //networkManager->getLogger()->info("Received packet with ID {} from client {}:{}", packetId, sessionId.ip, sessionId.port);
+                networkManager->getLogger()->info("Received packet with ID {} from client {}:{}", packetId, sessionId.ip, sessionId.port);
                 packet->decrypt(packetBuffer);
                 packet->handle(*this);
             } catch (const PacketSerializationException &e) {
@@ -160,15 +152,12 @@ int stratos::NetworkConnection::send(const ByteVec& data) {
     ByteVec sendBuffer;
     writeVarInt(sendBuffer, static_cast<int>(data.size()));
     sendBuffer.insert(sendBuffer.end(), data.begin(), data.end());
-    if (sendBuffer.size() > mtu) {
-        ByteVec buffer;
-        buffer.reserve(mtu);
-        buffer.insert(buffer.end(), std::make_move_iterator(sendBuffer.begin()), std::make_move_iterator(sendBuffer.begin() + mtu));
-        sendQueue.enqueue(buffer);
-        return mtu;
-    }
-
     sendQueue.enqueue(sendBuffer);
+
+#ifdef __linux__
+    if (bool expected = false; dirty.compare_exchange_strong(expected, true))
+        eventLoop->notifySend(socketFd);
+#endif
     return static_cast<int>(sendBuffer.size());
 }
 int stratos::NetworkConnection::handleReceive() {
@@ -199,16 +188,15 @@ int stratos::NetworkConnection::flushSendQueue() {
     ByteVec buffer;
     buffer.reserve(mtu);
 
-    size_t bytesSent = 0;
+    int totalBytesSent = 0;
     while (sendQueue.try_dequeue(buffer)) {
-        if (send(buffer, static_cast<int>(buffer.size()), 0) == SOCKET_ERROR) {
+        const int bytesSent = send(buffer, static_cast<int>(buffer.size()), 0);
+        if (bytesSent == SOCKET_ERROR)
             return -1;
-        }
-
-        bytesSent += buffer.size();
+        totalBytesSent += bytesSent;
     }
 
-    return static_cast<int>(bytesSent);
+    return totalBytesSent;
 }
 bool stratos::NetworkManager::start() {
     if (running) throw std::runtime_error("Attempted to start NetworkManager while it is already running");
@@ -301,7 +289,7 @@ void stratos::NetworkManager::processIncomingConnections() {
 void stratos::BossThread::start() {
     if (running.exchange(true)) return;
 
-    workers = std::vector<std::unique_ptr<WorkerThread>>();
+    workers = std::vector<std::shared_ptr<WorkerThread>>();
     workers.reserve(workerThreads);
 
     thread = std::thread([this] {
@@ -317,13 +305,23 @@ void stratos::BossThread::start() {
 
                     // Create a new session for the client
                     try {
-                        const auto connection = std::make_shared<NetworkConnection>(socket, ip, port);
+                        std::shared_ptr<NetworkConnection> connection;
                         if (workers.size() < workerThreads) {
-                            auto worker = std::make_unique<WorkerThread>(network, workers.size());
+                            auto worker = std::make_shared<WorkerThread>(network, workers.size());
                             worker->start();
+#ifdef __linux__
+                            connection = std::make_shared<NetworkConnection>(socket, ip, port, worker);
+#else
+                            connection = std::make_shared<NetworkConnection>(socket, ip, port);
+#endif
                             worker->addConnection(connection);
                             workers.push_back(std::move(worker));
                         } else {
+#ifdef __linux__
+                            connection = std::make_shared<NetworkConnection>(socket, ip, port, workers[connectionCount % workerThreads]);
+#else
+                            connection = std::make_shared<NetworkConnection>(socket, ip, port);
+#endif
                             workers[connectionCount % workerThreads]->addConnection(connection);
                         }
 
@@ -377,7 +375,7 @@ void stratos::WorkerThread::start() {
 
                 for (const auto& conn : connections) {
                     FD_SET(conn->getFd(), &readSet);
-                    if (!conn->getSendQueue().size_approx()) FD_SET(conn->getFd(), &writeSet);
+                    if (conn->getSendQueue().size_approx() > 0) FD_SET(conn->getFd(), &writeSet);
                     if (conn->getFd() > maxFd) maxFd = conn->getFd();
                 }
 
@@ -400,6 +398,8 @@ void stratos::WorkerThread::start() {
                     }
                 }
 #elifdef __linux__
+                processSendNotifications();
+
                 constexpr int MAX_EVENTS = 64;
                 epoll_event   events[MAX_EVENTS];
 
@@ -429,7 +429,11 @@ void stratos::WorkerThread::start() {
                         // If queue is empty, remove EPOLLOUT to prevent epoll wakeups
                         epoll_event ev{};
                         ev.events = EPOLLIN | EPOLLET; // Edge-triggered, no out until we have data to send
-                        if (conn->getSendQueue().size_approx() > 0) ev.events |= EPOLLOUT;
+                        if (conn->getSendQueue().size_approx() > 0) {
+                            ev.events |= EPOLLOUT;
+                        } else {
+                            conn->dirty.store(false);
+                        }
                         ev.data.fd = fd;
                         epoll_ctl(epollFd, EPOLL_CTL_MOD, fd, &ev);
                     }
@@ -467,6 +471,11 @@ void stratos::WorkerThread::removeConnection(const std::shared_ptr<NetworkConnec
     std::erase(connections, connection);
     connectionCount--;
 }
+#ifdef __linux__
+void stratos::WorkerThread::notifySend(const SocketFd& socketFd) {
+    sendNotifyQueue.enqueue(socketFd);
+}
+#endif
 void stratos::WorkerThread::processIncomingConnections() {
 
     std::lock_guard lock(connectionMutex);
@@ -490,3 +499,14 @@ void stratos::WorkerThread::processIncomingConnections() {
         }
     }
 }
+#ifdef __linux__
+void stratos::WorkerThread::processSendNotifications() {
+    SocketFd socketFd;
+    while (sendNotifyQueue.try_dequeue(socketFd)) {
+        epoll_event ev{};
+        ev.events = EPOLLIN | EPOLLOUT| EPOLLET; // Edge-triggered, no out until we have data to send
+        ev.data.fd = socketFd;
+        epoll_ctl(epollFd, EPOLL_CTL_MOD, socketFd, &ev);
+    }
+}
+#endif

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -33,19 +33,77 @@ void stratos::NetworkSession::tick() {
 
     // Empty received queue
     // TODO: Should we always empty or consume a fix amount per tick?
-    ByteVec buffer;
+    processReceived();
+
+    // Attempt to empty the recvBuffer
+    handleRawReceived();
+}
+void stratos::NetworkSession::processReceived() {
     ByteVec segment;
     while (connection->receive(segment) > 0) {
-        buffer.insert(buffer.end(), std::make_move_iterator(segment.begin()), std::make_move_iterator(segment.end()));
+        recvBuffer.insert(recvBuffer.end(), std::make_move_iterator(segment.begin()), std::make_move_iterator(segment.end()));
         segment.clear();
     }
-
-    if (!buffer.empty())
-        handleReceived(buffer);
 }
-void stratos::NetworkSession::handleReceived(ByteVec& data) {
-    // TODO: Begin handling Java packets!!!
-    std::cout << "Received data from client " << sessionId.ip << ":" << sessionId.port << std::endl;
+void stratos::NetworkSession::handleRawReceived() {
+    size_t offset = 0;
+    while (recvBuffer.size() > 0) {
+        if (protocolState == Handshaking) {
+            // Attempt to read the LegacyServerListPing
+            try {
+                if (const uint8_t id = readUnsignedByte(recvBuffer, offset); id == LegacyServerListPing::ID) {
+                    PacketBuffer buffer(recvBuffer);
+                    LegacyServerListPing packet;
+                    packet.decrypt(buffer);
+                    packet.handle(*this);
+
+                    const size_t newOffset = buffer.getOffset();
+                    recvBuffer.erase(recvBuffer.begin(), recvBuffer.begin() + newOffset);
+                    continue;
+                }
+            } catch (PacketSerializationException & ignored) {}
+        }
+
+        if (recvBuffer.size() < 6) {
+            // Not enough data to read a packet, wait for more data
+            return;
+        }
+
+        try {
+            const int packetLength = readVarInt(recvBuffer, offset);
+            if (packetLength < 0 || packetLength > recvBuffer.size() - offset) {
+                // Not enough data to read a full packet, wait for more data
+                return;
+            }
+
+            PacketBuffer packetBuffer(recvBuffer, offset);
+            try {
+                const int packetId = packetBuffer.readVarInt();
+                auto       packetKey = PacketKey{protocolState, Serverbound, packetId};
+                const auto packet = PacketRegistry::instance().create(packetKey);
+                if (!packet) {
+                    networkManager->getLogger()->error("Received unknown packet with ID {} from client {}:{}", packetId, sessionId.ip, sessionId.port);
+                    recvBuffer.erase(recvBuffer.begin(), recvBuffer.begin() + offset + packetLength);
+                    return;
+                }
+
+                networkManager->getLogger()->info("Received packet with ID {} from client {}:{}", packetId, sessionId.ip, sessionId.port);
+                packet->decrypt(packetBuffer);
+                packet->handle(*this);
+            } catch (const PacketSerializationException &e) {
+                networkManager->getLogger()->error("Failed to read packet from client {}:{}: {}", sessionId.ip, sessionId.port, e.what());
+            } catch (const std::exception &e) {
+                networkManager->getLogger()->error("Encountered an exception when handing a packet for client {}:{}: {}", sessionId.ip, sessionId.port, e.what());
+            }
+
+            recvBuffer.erase(recvBuffer.begin(), recvBuffer.begin() + offset + packetLength);
+        } catch (const PacketSerializationException& ignored) {
+            // Not enough data to read a packet, wait for more data
+            break;
+        } catch (const std::exception& e) {
+            networkManager->getLogger()->error("Failed to read packet from client {}:{}: {}", sessionId.ip, sessionId.port, e.what());
+        }
+    }
 }
 void stratos::NetworkSession::dispose() const {
     networkManager->getLogger()->info("Disposing network session for client {}:{}", sessionId.ip, sessionId.port);

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -38,6 +38,36 @@ void stratos::NetworkSession::tick() {
     // Attempt to empty the recvBuffer
     handleRawReceived();
 }
+void stratos::NetworkSession::send(const ByteVec& data) const {
+    if (!isStale()) connection->send(data);
+}
+void stratos::NetworkSession::send(ClientboundPacket& packet) const {
+    send(std::move(packet));
+}
+void stratos::NetworkSession::send(ClientboundPacket&& packet) const {
+    if (!isStale()) {
+        PacketBuffer buffer;
+        buffer.writeVarInt(packet.getId());
+        packet.encrypt(buffer);
+        connection->send(buffer.getBuffer());
+    }
+}
+void stratos::NetworkSession::sendLegacyPong() const {
+    send(LegacyServerListPong(47, "1.21.5", "A Minecraft Server", 0, 20));
+    connection->close();
+}
+void stratos::NetworkSession::handleClientHandshake(const ClientHandshake& packet) {
+    if (packet.intent == ClientHandshake::Intent::Status)
+        protocolState = Status;
+}
+void stratos::NetworkSession::handleStatusRequest() const {
+    if (protocolState == Status)
+        send(StatusResponse("{\"version\":{\"name\":\"1.21.5\",\"protocol\":770},\"players\":{\"max\":20,\"online\":0,\"sample\":[]},\"description\":{\"text\":\"A Minecraft Server\"}}"));
+}
+void stratos::NetworkSession::handlePingRequest(const int64_t timestamp) const {
+    if (protocolState == Status)
+        send(PongResponse(timestamp));
+}
 void stratos::NetworkSession::processReceived() {
     ByteVec segment;
     while (connection->receive(segment) > 0) {
@@ -46,13 +76,25 @@ void stratos::NetworkSession::processReceived() {
     }
 }
 void stratos::NetworkSession::handleRawReceived() {
+    // std::cout << "Handling raw received data (" << recvBuffer.size() << ")for client " << sessionId.ip << ":" << sessionId.port << ": ";
+    // for (int i = 0; i < recvBuffer.size(); ++i) {
+    //     printf("%02X ", recvBuffer.data()[i]);
+    // }
+    // std::cout << "  |  ";
+    // for (size_t i = 0; i < recvBuffer.size(); ++i) {
+    //     const char c = (std::isprint(recvBuffer.data()[i]) ? recvBuffer.data()[i] : '.');
+    //     std::cout << c;
+    // }
+    // std::cout << std::endl;
+
     size_t offset = 0;
     while (recvBuffer.size() > 0) {
         if (protocolState == Handshaking) {
             // Attempt to read the LegacyServerListPing
             try {
-                if (const uint8_t id = readUnsignedByte(recvBuffer, offset); id == LegacyServerListPing::ID) {
-                    PacketBuffer buffer(recvBuffer);
+                size_t legacyPingOffset = 0;
+                if (const uint8_t id = readUnsignedByte(recvBuffer, legacyPingOffset); id == LegacyServerListPing::ID) {
+                    PacketBuffer buffer(recvBuffer, legacyPingOffset);
                     LegacyServerListPing packet;
                     packet.decrypt(buffer);
                     packet.handle(*this);
@@ -64,14 +106,9 @@ void stratos::NetworkSession::handleRawReceived() {
             } catch (PacketSerializationException & ignored) {}
         }
 
-        if (recvBuffer.size() < 6) {
-            // Not enough data to read a packet, wait for more data
-            return;
-        }
-
         try {
             const int packetLength = readVarInt(recvBuffer, offset);
-            if (packetLength < 0 || packetLength > recvBuffer.size() - offset) {
+            if (packetLength <= 0 || packetLength > recvBuffer.size() - offset) {
                 // Not enough data to read a full packet, wait for more data
                 return;
             }
@@ -87,7 +124,7 @@ void stratos::NetworkSession::handleRawReceived() {
                     return;
                 }
 
-                networkManager->getLogger()->info("Received packet with ID {} from client {}:{}", packetId, sessionId.ip, sessionId.port);
+                //networkManager->getLogger()->info("Received packet with ID {} from client {}:{}", packetId, sessionId.ip, sessionId.port);
                 packet->decrypt(packetBuffer);
                 packet->handle(*this);
             } catch (const PacketSerializationException &e) {
@@ -120,26 +157,29 @@ int  stratos::NetworkConnection::receive(ByteVec& data) {
     return 0;
 }
 int stratos::NetworkConnection::send(const ByteVec& data) {
-    if (data.size() > mtu) {
+    ByteVec sendBuffer;
+    writeVarInt(sendBuffer, static_cast<int>(data.size()));
+    sendBuffer.insert(sendBuffer.end(), data.begin(), data.end());
+    if (sendBuffer.size() > mtu) {
         ByteVec buffer;
         buffer.reserve(mtu);
-        buffer.insert(buffer.end(), std::make_move_iterator(data.begin()), std::make_move_iterator(data.begin() + mtu));
+        buffer.insert(buffer.end(), std::make_move_iterator(sendBuffer.begin()), std::make_move_iterator(sendBuffer.begin() + mtu));
         sendQueue.enqueue(buffer);
         return mtu;
     }
 
-    sendQueue.enqueue(data);
-    return static_cast<int>(data.size());
+    sendQueue.enqueue(sendBuffer);
+    return static_cast<int>(sendBuffer.size());
 }
 int stratos::NetworkConnection::handleReceive() {
     ByteVec buffer;
     ByteVec segment;
-    segment.reserve(4096);
+    segment.resize(mtu);
     int totalReceived = 0;
 
     while (true) {
         int received              = 0;
-        totalReceived += received = receive(4096, segment);
+        totalReceived += received = receive(mtu, segment);
         if (received == 0) {
             return 0;
         }

--- a/src/network/Network.h
+++ b/src/network/Network.h
@@ -87,7 +87,11 @@ class NetworkConnection final : public TCPConnection {
     using TCPConnection::receive;
     using TCPConnection::send;
 
+#ifdef __linux__
+    NetworkConnection(const SocketFd socketFd, const std::string& address, const int& port, std::shared_ptr<WorkerThread> eventLoop) : TCPConnection(socketFd, address, port), eventLoop(std::move(eventLoop)) {}
+#else
     NetworkConnection(const SocketFd socketFd, const std::string& address, const int& port) : TCPConnection(socketFd, address, port) {}
+#endif
     ~NetworkConnection() override = default;
 
     [[nodiscard]] const moodycamel::ConcurrentQueue<ByteVec>& getSendQueue() const { return sendQueue; }
@@ -99,6 +103,10 @@ class NetworkConnection final : public TCPConnection {
   private:
     moodycamel::ConcurrentQueue<ByteVec> sendQueue = moodycamel::ConcurrentQueue<ByteVec>();
     moodycamel::ConcurrentQueue<ByteVec> receiveQueue = moodycamel::ConcurrentQueue<ByteVec>();
+#ifdef __linux__
+    std::atomic<bool> dirty = false; // Indicates if the connection has data to send
+    std::shared_ptr<WorkerThread> eventLoop;
+#endif
 
     int handleReceive();
     int flushSendQueue();
@@ -180,7 +188,7 @@ class BossThread final : public NetworkThread {
   private:
     int                                        workerThreads;
     int                                        connectionCount = 0;
-    std::vector<std::unique_ptr<WorkerThread>> workers;
+    std::vector<std::shared_ptr<WorkerThread>> workers;
 };
 
 class WorkerThread final : public NetworkThread {
@@ -191,6 +199,9 @@ class WorkerThread final : public NetworkThread {
 
     void addConnection(std::shared_ptr<NetworkConnection> connection);
     void removeConnection(const std::shared_ptr<NetworkConnection>& connection);
+#ifdef __linux__
+    void notifySend(const SocketFd& socketFd);
+#endif
 
     [[nodiscard]] int getId() const { return id; }
     [[nodiscard]] int getConnectionCount() const { return connectionCount; }
@@ -202,11 +213,14 @@ class WorkerThread final : public NetworkThread {
     std::mutex                                                      connectionMutex;
     std::vector<std::shared_ptr<NetworkConnection>>                 connections;
     moodycamel::ConcurrentQueue<std::shared_ptr<NetworkConnection>> inConnectionQueue;
-
-    void processIncomingConnections();
-
 #ifdef __linux__
     int epollFd = -1;
+    moodycamel::ConcurrentQueue<SocketFd> sendNotifyQueue;
+#endif
+
+    void processIncomingConnections();
+#ifdef __linux__
+    void processSendNotifications();
 #endif
 };
 } // namespace stratos

--- a/src/network/Network.h
+++ b/src/network/Network.h
@@ -119,6 +119,16 @@ class NetworkSession {
 
     void tick();
 
+    void send(const ByteVec& data) const;
+    void send(ClientboundPacket& packet) const;
+    void send(ClientboundPacket&& packet) const;
+
+    void sendLegacyPong() const;
+    void handleClientHandshake(const ClientHandshake& packet);
+    void handleStatusRequest() const;
+    void handlePingRequest(int64_t timestamp) const;
+
+
   private:
     NetworkManager* networkManager;
     SessionId       sessionId;

--- a/src/network/Network.h
+++ b/src/network/Network.h
@@ -20,6 +20,7 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 #include "concurrentqueue.h"
+#include "protocol/PacketCodec.h"
 #include "Socket.h"
 
 #include <memory>
@@ -123,9 +124,16 @@ class NetworkSession {
     SessionId       sessionId;
     std::shared_ptr<NetworkConnection>   connection;
 
+    ByteVec recvBuffer;
+
+    ProtocolState protocolState = Handshaking;
+    ClientHandshake::Intent sessionIntent = ClientHandshake::Intent::None;
     bool connected = true;
 
-    void handleReceived(ByteVec& data);
+    // Clears the received segments and moves the data to the recvBuffer
+    void processReceived();
+    // Handles the raw received data, frames data into received packet(s), then handles the packet(s) if any
+    void handleRawReceived();
     void dispose() const;
 
     friend class NetworkManager;

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -250,18 +250,6 @@ int stratos::TCPConnection::receive(const int length, ByteVec& buffer) {
         return bytes; // Return 0 or -1 to indicate closure or error
     }
     buffer.resize(bytes);
-
-    // std::cout << "Received " << bytes << " bytes: ";
-    // for (int i = 0; i < bytes; ++i) {
-    //     printf("%02X ", buffer.data()[i]);
-    // }
-    // std::cout << "  |  ";
-    // for (size_t i = 0; i < bytes; ++i) {
-    //     const char c = (std::isprint(buffer.data()[i]) ? buffer.data()[i] : '.');
-    //     std::cout << c;
-    // }
-    // std::cout << std::endl;
-
     return bytes;
 }
 
@@ -273,23 +261,12 @@ int stratos::TCPConnection::receive(const int length, ByteVec& buffer) {
  * @return Number of bytes sent, or SOCKET_ERROR if an error occurred.
  */
 int stratos::TCPConnection::send(const ByteVec& buffer, const int length, const int flags) {
-    // std::cout << "Sending " << length << " bytes: ";
-    // for (int i = 0; i < buffer.size(); ++i) {
-    //     printf("%02X ", buffer.data()[i]);
-    // }
-    // std::cout << "  |  ";
-    // for (size_t i = 0; i < buffer.size(); ++i) {
-    //     const char c = (std::isprint(buffer.data()[i]) ? buffer.data()[i] : '.');
-    //     std::cout << c;
-    // }
-    // std::cout << std::endl;
-
     const int bytes = ::send(socketFd, reinterpret_cast<const char*>(buffer.data()), length, flags);
     if (bytes == SOCKET_ERROR) {
 #if _WIN32
-        if (const int err = WSAGetLastError(); err == WSAEWOULDBLOCK)
+        if (int err = WSAGetLastError(); err == WSAEWOULDBLOCK)
 #else
-        if (const int err = errno; err == EAGAIN || err == EWOULDBLOCK)
+        if (int err = errno; err == EAGAIN || err == EWOULDBLOCK)
 #endif
             return 0;
         return SOCKET_ERROR;
@@ -317,7 +294,7 @@ int stratos::setNonBlocking(SocketFd socketFd) {
     return (flags != -1 && fcntl(socketFd, F_SETFL, flags | O_NONBLOCK) != -1) ? 0 : -1;
 #endif
 }
-int stratos::getMTUForSocket(const SocketFd socketFd) {
+size_t stratos::getMTUForSocket(const SocketFd socketFd) {
 #ifdef _WIN32
     sockaddr_in addr{};
     int         addrLen = sizeof(addr);

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #endif
 
+#include <cstdint>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -244,7 +245,23 @@ int stratos::TCPConnection::receive(const int length, ByteVec& buffer) {
         if (err == ECONNRESET) return 0; // Connection reset by peer
 #endif
     }
+    if (bytes < 0) {
+        buffer.resize(0);
+        return bytes; // Return 0 or -1 to indicate closure or error
+    }
     buffer.resize(bytes);
+
+    // std::cout << "Received " << bytes << " bytes: ";
+    // for (int i = 0; i < bytes; ++i) {
+    //     printf("%02X ", buffer.data()[i]);
+    // }
+    // std::cout << "  |  ";
+    // for (size_t i = 0; i < bytes; ++i) {
+    //     const char c = (std::isprint(buffer.data()[i]) ? buffer.data()[i] : '.');
+    //     std::cout << c;
+    // }
+    // std::cout << std::endl;
+
     return bytes;
 }
 
@@ -256,6 +273,17 @@ int stratos::TCPConnection::receive(const int length, ByteVec& buffer) {
  * @return Number of bytes sent, or SOCKET_ERROR if an error occurred.
  */
 int stratos::TCPConnection::send(const ByteVec& buffer, const int length, const int flags) {
+    // std::cout << "Sending " << length << " bytes: ";
+    // for (int i = 0; i < buffer.size(); ++i) {
+    //     printf("%02X ", buffer.data()[i]);
+    // }
+    // std::cout << "  |  ";
+    // for (size_t i = 0; i < buffer.size(); ++i) {
+    //     const char c = (std::isprint(buffer.data()[i]) ? buffer.data()[i] : '.');
+    //     std::cout << c;
+    // }
+    // std::cout << std::endl;
+
     const int bytes = ::send(socketFd, reinterpret_cast<const char*>(buffer.data()), length, flags);
     if (bytes == SOCKET_ERROR) {
 #if _WIN32

--- a/src/network/Socket.h
+++ b/src/network/Socket.h
@@ -105,8 +105,8 @@ class TCPServer final : public SocketServer {
 #endif
 };
 
-int setNonBlocking(SocketFd socketFd);
-int getMTUForSocket(SocketFd socketFd);
+int    setNonBlocking(SocketFd socketFd);
+size_t getMTUForSocket(SocketFd socketFd);
 
 class SocketConnection : public Socket {
   public:
@@ -127,11 +127,11 @@ class TCPConnection : public SocketConnection {
     int  send(const ByteVec& buffer, int length, int flags) override;
     void close() override;
 
-    [[nodiscard]] int getMtu() const { return mtu; }
+    [[nodiscard]] size_t getMtu() const { return mtu; }
     [[nodiscard]] bool isClosed() const { return closed; }
 
   protected:
-    int mtu;
+    size_t mtu;
     bool closed = false;
 };
 } // namespace stratos

--- a/src/network/protocol/Packet.cpp
+++ b/src/network/protocol/Packet.cpp
@@ -1,0 +1,38 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#include "Packet.h"
+
+#include "PacketCodec.h"
+
+void stratos::PacketRegistry::setup() {
+    // Handshaking Packets
+    registerPacket({Handshaking, Serverbound, ClientHandshake::ID}, [] { return std::make_unique<ClientHandshake>(); });
+    registerPacket({Handshaking, Serverbound, LegacyServerListPing::ID}, [] { return std::make_unique<LegacyServerListPing>(); });
+    registerPacket({Handshaking, Clientbound, LegacyServerListPong::ID}, [] { return std::make_unique<LegacyServerListPong>(); });
+
+    // Status Packets
+    registerPacket({Status, Serverbound, StatusRequest::ID}, [] { return std::make_unique<StatusRequest>(); });
+    registerPacket({Status, Serverbound, PingRequest::ID}, [] { return std::make_unique<PingRequest>(); });
+    registerPacket({Status, Clientbound, StatusResponse::ID}, [] { return std::make_unique<StatusResponse>(); });
+    registerPacket({Status, Clientbound, PongResponse::ID}, [] { return std::make_unique<PongResponse>(); });
+
+
+
+}

--- a/src/network/protocol/Packet.h
+++ b/src/network/protocol/Packet.h
@@ -36,14 +36,16 @@ public:
     int id;
 };
 
-class ClientboundPacket : public Packet {
+class ClientboundPacket : virtual public Packet {
   public:
     explicit ClientboundPacket(const int id) : Packet(id) {}
+    virtual void decrypt(PacketBuffer& buffer) override {}
 };
 
-class ServerboundPacket : public Packet {
+class ServerboundPacket : virtual public Packet {
   public:
     explicit ServerboundPacket(const int id) : Packet(id) {}
+    virtual void encrypt(PacketBuffer& buffer) override {}
     virtual void handle(NetworkSession& session) = 0;
 };
 

--- a/src/network/protocol/Packet.h
+++ b/src/network/protocol/Packet.h
@@ -1,0 +1,52 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#ifndef PACKET_H
+#define PACKET_H
+
+namespace stratos {
+class NetworkSession;
+class PacketBuffer;
+
+class Packet {
+public:
+    explicit Packet(const int id) : id(id) {}
+    virtual ~Packet();
+
+    int getId() const { return id; }
+    virtual void decrypt(PacketBuffer& buffer) = 0;
+    virtual void encrypt(PacketBuffer& buffer) = 0;
+
+    int id;
+};
+
+class ClientboundPacket : public Packet {
+  public:
+    explicit ClientboundPacket(const int id) : Packet(id) {}
+};
+
+class ServerboundPacket : public Packet {
+  public:
+    explicit ServerboundPacket(const int id) : Packet(id) {}
+    virtual void handle(NetworkSession& session) = 0;
+};
+
+} // namespace stratos
+
+#endif //PACKET_H

--- a/src/network/protocol/Packet.h
+++ b/src/network/protocol/Packet.h
@@ -19,35 +19,102 @@
 
 #ifndef PACKET_H
 #define PACKET_H
+#include <functional>
+#include <memory>
 
 namespace stratos {
 class NetworkSession;
 class PacketBuffer;
 
+enum ProtocolState { Handshaking = 0x00, Status = 0x01, Login = 0x02, Configuration = 0x03, Play = 0x04 };
+enum PacketDirection { Clientbound = 0x00, Serverbound = 0x01 };
+
 class Packet {
 public:
     explicit Packet(const int id) : id(id) {}
-    virtual ~Packet();
+    virtual ~Packet() = default;
 
     int getId() const { return id; }
     virtual void decrypt(PacketBuffer& buffer) = 0;
     virtual void encrypt(PacketBuffer& buffer) = 0;
+    virtual void handle(NetworkSession& session) = 0;
 
     int id;
 };
 
 class ClientboundPacket : virtual public Packet {
-  public:
+public:
     explicit ClientboundPacket(const int id) : Packet(id) {}
-    virtual void decrypt(PacketBuffer& buffer) override {}
+    ~ClientboundPacket() override = default;
+    void decrypt(PacketBuffer& buffer) override {}
+    void handle(NetworkSession& session) override {}
 };
 
 class ServerboundPacket : virtual public Packet {
-  public:
+public:
     explicit ServerboundPacket(const int id) : Packet(id) {}
-    virtual void encrypt(PacketBuffer& buffer) override {}
-    virtual void handle(NetworkSession& session) = 0;
+    ~ServerboundPacket() override = default;
+    void encrypt(PacketBuffer& buffer) override {}
 };
+
+struct PacketKey {
+    int state;
+    int direction;
+    int id;
+
+    bool operator==(const PacketKey& other) const;
+};
+
+inline bool PacketKey::operator==(const PacketKey& other) const {
+    return state == other.state && direction == other.direction && id == other.id;
+}
+}
+
+template <>
+struct std::hash<stratos::PacketKey> {
+    std::size_t operator()(const stratos::PacketKey& key) const noexcept {
+        const std::size_t h1 = std::hash<int>()(key.state);
+        const std::size_t h2 = std::hash<int>()(key.direction);
+        const std::size_t h3 = std::hash<int>()(key.id);
+
+        std::size_t seed = h1;
+        seed ^= h2 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        seed ^= h3 + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+    }
+};
+
+namespace stratos {
+class PacketRegistry final {
+  public:
+    typedef std::function<std::unique_ptr<Packet>()> PacketFactory;
+
+    PacketRegistry();
+
+    static PacketRegistry& instance() {
+        static PacketRegistry registry;
+        return registry;
+    }
+
+    std::unique_ptr<Packet> create(const PacketKey& key);
+
+  private:
+    std::unordered_map<PacketKey, PacketFactory> factories ;
+
+    void setup();
+    void registerPacket(const PacketKey& key, PacketFactory factory);
+};
+
+inline PacketRegistry::PacketRegistry() : factories() {
+    setup();
+}
+inline std::unique_ptr<Packet> PacketRegistry::create(const PacketKey& key) {
+    if (const auto it = factories.find(key); it != factories.end()) return it->second();
+    return nullptr;
+}
+inline void PacketRegistry::registerPacket(const PacketKey& key, PacketFactory factory) {
+    factories[key] = std::move(factory);
+}
 
 } // namespace stratos
 

--- a/src/network/protocol/PacketCodec.cpp
+++ b/src/network/protocol/PacketCodec.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#include "PacketCodec.h"
+#include "PacketSerialization.h"
+
+void stratos::ClientHandshake::decrypt(PacketBuffer& buffer) {
+    protocolVersion = buffer.readInt();
+    serverAddress   = buffer.readString(255);
+    serverPort      = buffer.readUnsignedShort();
+
+    // Read the intent
+    intent = buffer.readXEnum(std::function(readVarInt), std::function([](const int& value) -> Intent {
+                                  switch (value) {
+                                  case 0x01:
+                                      return Intent::Status;
+                                  case 0x02:
+                                      return Intent::Login;
+                                  case 0x03:
+                                      return Intent::Transfer;
+                                  default:
+                                      throw PacketSerializationException("Unknown intent value: " + std::to_string(value));
+                                  }
+                              }));
+}
+void stratos::ClientHandshake::handle(NetworkSession& session) {
+
+}
+void stratos::LegacyServerListPong::encrypt(PacketBuffer& buffer) {
+    const std::string payload = "§1\0" + std::to_string(protocolVersion) + "\0" + version + "\0" + motd + "\0" + "\0" + std::to_string(onlinePlayers) + "\0" + std::to_string(maxPlayers);
+    buffer.writeStringUTF16BE(payload);
+}

--- a/src/network/protocol/PacketCodec.cpp
+++ b/src/network/protocol/PacketCodec.cpp
@@ -26,7 +26,7 @@ void stratos::ClientHandshake::decrypt(PacketBuffer& buffer) {
     serverPort      = buffer.readUnsignedShort();
 
     // Read the intent
-    intent = buffer.readXEnum(std::function(readVarInt), std::function([](const int& value) -> Intent {
+    intent = buffer.readXEnum<int, Intent>(readVarInt, [](const int& value) -> Intent {
                                   switch (value) {
                                   case 0x01:
                                       return Intent::Status;
@@ -37,12 +37,23 @@ void stratos::ClientHandshake::decrypt(PacketBuffer& buffer) {
                                   default:
                                       throw PacketSerializationException("Unknown intent value: " + std::to_string(value));
                                   }
-                              }));
+                              });
 }
-void stratos::ClientHandshake::handle(NetworkSession& session) {
-
-}
+void stratos::ClientHandshake::handle(NetworkSession& session) {}
+void stratos::LegacyServerListPing::decrypt(PacketBuffer& buffer) {}
+void stratos::LegacyServerListPing::handle(NetworkSession& session) {}
 void stratos::LegacyServerListPong::encrypt(PacketBuffer& buffer) {
-    const std::string payload = "§1\0" + std::to_string(protocolVersion) + "\0" + version + "\0" + motd + "\0" + "\0" + std::to_string(onlinePlayers) + "\0" + std::to_string(maxPlayers);
+    const std::string payload =
+        "§1\0" + std::to_string(protocolVersion) + "\0" + version + "\0" + motd + "\0" + "\0" + std::to_string(onlinePlayers) + "\0" + std::to_string(maxPlayers);
     buffer.writeStringUTF16BE(payload);
 }
+void stratos::StatusResponse::encrypt(PacketBuffer& buffer) {
+    buffer.writeString(jsonResponse, 32767);
+}
+void stratos::PongResponse::encrypt(PacketBuffer& buffer) {
+    buffer.writeLong(timestamp);
+}
+void stratos::StatusRequest::decrypt(PacketBuffer& buffer) {}
+void stratos::StatusRequest::handle(NetworkSession& session) {}
+void stratos::PingRequest::decrypt(PacketBuffer& buffer) {}
+void stratos::PingRequest::handle(NetworkSession& session) {}

--- a/src/network/protocol/PacketCodec.cpp
+++ b/src/network/protocol/PacketCodec.cpp
@@ -18,10 +18,12 @@
  */
 
 #include "PacketCodec.h"
+
+#include "network/Network.h"
 #include "PacketSerialization.h"
 
 void stratos::ClientHandshake::decrypt(PacketBuffer& buffer) {
-    protocolVersion = buffer.readInt();
+    protocolVersion = buffer.readVarInt();
     serverAddress   = buffer.readString(255);
     serverPort      = buffer.readUnsignedShort();
 
@@ -39,10 +41,25 @@ void stratos::ClientHandshake::decrypt(PacketBuffer& buffer) {
                                   }
                               });
 }
-void stratos::ClientHandshake::handle(NetworkSession& session) {}
-void stratos::LegacyServerListPing::decrypt(PacketBuffer& buffer) {}
-void stratos::LegacyServerListPing::handle(NetworkSession& session) {}
+void stratos::ClientHandshake::handle(NetworkSession& session) {
+    session.handleClientHandshake(*this);
+}
+void stratos::LegacyServerListPing::decrypt(PacketBuffer& buffer) {
+    payload = buffer.readByte();
+
+    // None of this matters, but we need to read the payload to avoid deserialization errors
+    buffer.readByte(); // Packet identifier
+    buffer.readStringUTF16BE(); // MC|Pinghost
+    buffer.readShort(); // Remaining length
+    buffer.readByte(); // Protocol version
+    buffer.readStringUTF16BE(); // Server address
+    buffer.readInt(); // Server port
+}
+void stratos::LegacyServerListPing::handle(NetworkSession& session) {
+    session.sendLegacyPong();
+}
 void stratos::LegacyServerListPong::encrypt(PacketBuffer& buffer) {
+    buffer.writeByte(0xFF); // Kick packet identifier
     const std::string payload =
         "§1\0" + std::to_string(protocolVersion) + "\0" + version + "\0" + motd + "\0" + "\0" + std::to_string(onlinePlayers) + "\0" + std::to_string(maxPlayers);
     buffer.writeStringUTF16BE(payload);
@@ -54,6 +71,12 @@ void stratos::PongResponse::encrypt(PacketBuffer& buffer) {
     buffer.writeLong(timestamp);
 }
 void stratos::StatusRequest::decrypt(PacketBuffer& buffer) {}
-void stratos::StatusRequest::handle(NetworkSession& session) {}
-void stratos::PingRequest::decrypt(PacketBuffer& buffer) {}
-void stratos::PingRequest::handle(NetworkSession& session) {}
+void stratos::StatusRequest::handle(NetworkSession& session) {
+    session.handleStatusRequest();
+}
+void stratos::PingRequest::decrypt(PacketBuffer& buffer) {
+    timestamp = buffer.readLong();
+}
+void stratos::PingRequest::handle(NetworkSession& session) {
+    session.handlePingRequest(timestamp);
+}

--- a/src/network/protocol/PacketCodec.h
+++ b/src/network/protocol/PacketCodec.h
@@ -115,6 +115,7 @@ class PingRequest final : public ServerboundPacket {
   public:
     constexpr static int ID = 0x01;
 
+    int64_t timestamp = 0;
     explicit PingRequest() : Packet(ID), ServerboundPacket(ID) {}
     ~PingRequest() override = default;
     void decrypt(PacketBuffer& buffer) override;

--- a/src/network/protocol/PacketCodec.h
+++ b/src/network/protocol/PacketCodec.h
@@ -32,6 +32,7 @@ namespace stratos {
 class ClientHandshake final : public ServerboundPacket {
   public:
     enum class Intent {
+        None = 0,
         Status = 0x01,
         Login = 0x02,
         Transfer = 0x03
@@ -43,7 +44,8 @@ class ClientHandshake final : public ServerboundPacket {
     uint16_t serverPort = 0;
     Intent intent = Intent::Status;
 
-    explicit ClientHandshake() : ServerboundPacket(ID) {}
+    explicit ClientHandshake() : Packet(ID), ServerboundPacket(ID) {}
+    ~ClientHandshake() override = default;
     void decrypt(PacketBuffer& buffer) override;
     void handle(NetworkSession& session) override;
 };
@@ -53,7 +55,8 @@ public:
     constexpr static int ID = 0xFE;
     uint8_t payload = 0x01; // Legacy server list ping payload
 
-    explicit LegacyServerListPing() : ServerboundPacket(ID) {}
+    explicit LegacyServerListPing() : Packet(ID), ServerboundPacket(ID) {}
+    ~LegacyServerListPing() override = default;
     void decrypt(PacketBuffer& buffer) override;
     void handle(NetworkSession& session) override;
 };
@@ -67,8 +70,10 @@ public:
     int onlinePlayers;
     int         maxPlayers;
 
+    LegacyServerListPong() : Packet(ID), ClientboundPacket(ID), protocolVersion(0), version(""), motd(""), onlinePlayers(0), maxPlayers(0) {}
     LegacyServerListPong(const int protocol_version, const std::string& version, const std::string& motd, const int online_players, const int max_players)
-        : ClientboundPacket(ID), protocolVersion(protocol_version), version(version), motd(motd), onlinePlayers(online_players), maxPlayers(max_players) {}
+        : Packet(ID), ClientboundPacket(ID), protocolVersion(protocol_version), version(version), motd(motd), onlinePlayers(online_players), maxPlayers(max_players) {}
+    ~LegacyServerListPong() override = default;
     void encrypt(PacketBuffer& buffer) override;
 };
 
@@ -79,22 +84,29 @@ public:
     constexpr static int ID = 0x00;
     std::string          jsonResponse;
 
-    explicit StatusResponse(std::string&& jsonResponse) : ClientboundPacket(ID), jsonResponse(std::move(jsonResponse)) {}
-    void encrypt(PacketBuffer& buffer) override { buffer.writeString(jsonResponse, 32767); }
+    StatusResponse() : Packet(ID), ClientboundPacket(ID), jsonResponse("") {}
+    explicit StatusResponse(std::string&& jsonResponse) : Packet(ID), ClientboundPacket(ID), jsonResponse(std::move(jsonResponse)) {}
+    ~StatusResponse() override = default;
+    void encrypt(PacketBuffer& buffer) override;
 };
 
 class PongResponse final : public ClientboundPacket {
+public:
     constexpr static int ID = 0x01;
     int64_t timestamp;
 
-    explicit PongResponse(const int64_t timestamp) : ClientboundPacket(ID), timestamp(timestamp) {}
-    void encrypt(PacketBuffer& buffer) override { buffer.writeLong(timestamp); }
+    PongResponse() : Packet(ID), ClientboundPacket(ID), timestamp(0) {}
+    explicit PongResponse(const int64_t timestamp) : Packet(ID), ClientboundPacket(ID), timestamp(timestamp) {}
+    ~PongResponse() override = default;
+    void encrypt(PacketBuffer& buffer) override;
 };
 
 class StatusRequest final : public ServerboundPacket {
 public:
     constexpr static int ID = 0x00;
-    explicit StatusRequest() : ServerboundPacket(ID) {}
+
+    explicit StatusRequest() : Packet(ID), ServerboundPacket(ID) {}
+    ~StatusRequest() override = default;
     void decrypt(PacketBuffer& buffer) override;
     void handle(NetworkSession& session) override;
 };
@@ -103,7 +115,8 @@ class PingRequest final : public ServerboundPacket {
   public:
     constexpr static int ID = 0x01;
 
-    explicit PingRequest() : ServerboundPacket(ID) {}
+    explicit PingRequest() : Packet(ID), ServerboundPacket(ID) {}
+    ~PingRequest() override = default;
     void decrypt(PacketBuffer& buffer) override;
     void handle(NetworkSession& session) override;
 };

--- a/src/network/protocol/PacketCodec.h
+++ b/src/network/protocol/PacketCodec.h
@@ -1,0 +1,114 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#ifndef PACKETCODEC_H
+#define PACKETCODEC_H
+#include "Packet.h"
+#include "PacketSerialization.h"
+
+#include <cstdint>
+#include <string>
+
+namespace stratos {
+
+// Handshake Packets
+
+class ClientHandshake final : public ServerboundPacket {
+  public:
+    enum class Intent {
+        Status = 0x01,
+        Login = 0x02,
+        Transfer = 0x03
+    };
+
+    constexpr static int ID = 0x00;
+    int protocolVersion = 0;
+    std::string serverAddress = "";
+    uint16_t serverPort = 0;
+    Intent intent = Intent::Status;
+
+    explicit ClientHandshake() : ServerboundPacket(ID) {}
+    void decrypt(PacketBuffer& buffer) override;
+    void handle(NetworkSession& session) override;
+};
+
+class LegacyServerListPing final : public ServerboundPacket {
+public:
+    constexpr static int ID = 0xFE;
+    uint8_t payload = 0x01; // Legacy server list ping payload
+
+    explicit LegacyServerListPing() : ServerboundPacket(ID) {}
+    void decrypt(PacketBuffer& buffer) override;
+    void handle(NetworkSession& session) override;
+};
+
+class LegacyServerListPong final : public ClientboundPacket {
+public:
+    constexpr static int ID = 0xFF;
+    int protocolVersion;
+    std::string version;
+    std::string motd;
+    int onlinePlayers;
+    int         maxPlayers;
+
+    LegacyServerListPong(const int protocol_version, const std::string& version, const std::string& motd, const int online_players, const int max_players)
+        : ClientboundPacket(ID), protocolVersion(protocol_version), version(version), motd(motd), onlinePlayers(online_players), maxPlayers(max_players) {}
+    void encrypt(PacketBuffer& buffer) override;
+};
+
+// Status Packets
+
+class StatusResponse final : public ClientboundPacket {
+public:
+    constexpr static int ID = 0x00;
+    std::string          jsonResponse;
+
+    explicit StatusResponse(std::string&& jsonResponse) : ClientboundPacket(ID), jsonResponse(std::move(jsonResponse)) {}
+    void encrypt(PacketBuffer& buffer) override { buffer.writeString(jsonResponse, 32767); }
+};
+
+class PongResponse final : public ClientboundPacket {
+    constexpr static int ID = 0x01;
+    int64_t timestamp;
+
+    explicit PongResponse(const int64_t timestamp) : ClientboundPacket(ID), timestamp(timestamp) {}
+    void encrypt(PacketBuffer& buffer) override { buffer.writeLong(timestamp); }
+};
+
+class StatusRequest final : public ServerboundPacket {
+public:
+    constexpr static int ID = 0x00;
+    explicit StatusRequest() : ServerboundPacket(ID) {}
+    void decrypt(PacketBuffer& buffer) override;
+    void handle(NetworkSession& session) override;
+};
+
+class PingRequest final : public ServerboundPacket {
+  public:
+    constexpr static int ID = 0x01;
+
+    explicit PingRequest() : ServerboundPacket(ID) {}
+    void decrypt(PacketBuffer& buffer) override;
+    void handle(NetworkSession& session) override;
+};
+
+
+} // namespace stratos
+
+#endif //PACKETCODEC_H

--- a/src/network/protocol/PacketSerialization.cpp
+++ b/src/network/protocol/PacketSerialization.cpp
@@ -1,0 +1,228 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#include "PacketSerialization.h"
+
+#include <cstring>
+
+bool        stratos::readBoolean(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(bool));
+    const bool value = buffer[offset++] != 0;
+    return value;
+}
+int8_t      stratos::readByte(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(int8_t));
+    const auto value = static_cast<int8_t>(buffer[offset++]);
+    return value;
+}
+uint8_t     stratos::readUnsignedByte(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(uint8_t));
+    const auto value = static_cast<uint8_t>(buffer[offset++]);
+    return value;
+}
+short       stratos::readShort(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(short));
+    const auto high = static_cast<int16_t>(buffer[offset++]);
+    const auto low  = static_cast<int16_t>(buffer[offset++]);
+    return static_cast<short>(high << 8 | low & 0xFF);
+}
+uint16_t    stratos::readUnsignedShort(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(uint16_t));
+    const auto high = static_cast<uint16_t>(buffer[offset++]);
+    const auto low  = static_cast<uint16_t>(buffer[offset++]);
+    return static_cast<uint16_t>(high << 8 | low & 0xFF);
+}
+int         stratos::readInt(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(int));
+    const auto b1 = static_cast<int32_t>(buffer[offset++]);
+    const auto b2 = static_cast<int32_t>(buffer[offset++]);
+    const auto b3 = static_cast<int32_t>(buffer[offset++]);
+    const auto b4 = static_cast<int32_t>(buffer[offset++]);
+    return b1 << 24 | b2 << 16 | b3 << 8 | b4 & 0xFF;
+}
+int64_t        stratos::readLong(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(long));
+    int64_t result = 0;
+    for (int i = 0; i < 8; ++i) {
+        result |= static_cast<int64_t>(buffer[offset++]) << ((7 - i) * 8);
+    }
+    return result;
+}
+float       stratos::readFloat(const ByteVec& buffer, size_t& offset) {
+    isReadable(buffer, offset, sizeof(float));
+    const uint32_t bits = static_cast<uint32_t>(buffer[offset]) << 24 |
+                    static_cast<uint32_t>(buffer[offset + 1]) << 16 |
+                    static_cast<uint32_t>(buffer[offset + 2]) << 8 |
+                    static_cast<uint32_t>(buffer[offset + 3]);
+    offset += 4;
+    float value;
+    std::memcpy(&value, &bits, sizeof(float));
+    return value;
+}
+double      stratos::readDouble(const ByteVec& buffer, size_t& offset) {
+    uint64_t bits = 0;
+    for (int i = 0; i < 8; ++i)
+        bits |= static_cast<uint64_t>(buffer[offset++]) << ((7 - i) * 8);
+    double value;
+    std::memcpy(&value, &bits, sizeof(double));
+    return value;
+}
+std::string stratos::readString(const ByteVec& buffer, size_t& offset, const int maxChars) {
+    const uint32_t length = readVarInt(buffer, offset);
+
+    if (length > maxChars * 3)
+        throw PacketSerializationException("String: length exceeds UTF-8 byte size limit");
+    if (offset + length > buffer.size())
+        throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
+
+    std::string str(buffer.begin() + offset, buffer.begin() + offset + length);
+    offset += length;
+    if (const int utf16Units = countUTF16CodeUnits(str); utf16Units > maxChars) {
+        throw PacketSerializationException("String: character length exceeds maximum");
+    }
+
+    return str;
+}
+void        stratos::writeBoolean(ByteVec& buffer, const bool& value) {
+    buffer.push_back(static_cast<unsigned char>(value ? 1 : 0));
+}
+void        stratos::writeByte(ByteVec& buffer, const int8_t& value) {
+    buffer.push_back(static_cast<unsigned char>(value));
+}
+void        stratos::writeUnsignedByte(ByteVec& buffer, const uint8_t& value) {
+    buffer.push_back(value);
+}
+void        stratos::writeShort(ByteVec& buffer, const short& value) {
+    buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(value & 0xFF));
+}
+void        stratos::writeUnsignedShort(ByteVec& buffer, const uint16_t& value) {
+    buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(value & 0xFF));
+}
+void        stratos::writeInt(ByteVec& buffer, const int& value) {
+    buffer.push_back(static_cast<unsigned char>(value >> 24 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(value >> 16 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(value & 0xFF));
+}
+void        stratos::writeLong(ByteVec& buffer, const int64_t& value) {
+    for (int i = 7; i >= 0; --i) {
+        buffer.push_back(static_cast<unsigned char>(value >> (i * 8) & 0xFF));
+    }
+}
+void        stratos::writeFloat(ByteVec& buffer, const float& value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(float));
+    buffer.push_back(static_cast<unsigned char>(bits >> 24 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(bits >> 16 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(bits >> 8 & 0xFF));
+    buffer.push_back(static_cast<unsigned char>(bits & 0xFF));
+}
+void        stratos::writeDouble(ByteVec& buffer, const double& value) {
+    uint64_t bits;
+    std::memcpy(&bits, &value, sizeof(double));
+    for (int i = 7; i >= 0; --i) {
+        buffer.push_back(static_cast<unsigned char>((bits >> (i * 8)) & 0xFF));
+    }
+}
+void        stratos::writeString(ByteVec& buffer, const std::string& value, const int maxChars) {
+    if (const int utf16Units = countUTF16CodeUnits(value); utf16Units > maxChars) {
+        throw PacketSerializationException("String: exceeds character limit");
+    }
+
+    if (value.size() > maxChars * 3) {
+        throw PacketSerializationException("String: exceeds UTF-8 byte size limit");
+    }
+
+    writeVarInt(buffer, static_cast<uint32_t>(value.size()));
+    buffer.insert(buffer.end(), value.begin(), value.end());
+}
+int         stratos::readVarInt(const ByteVec& buffer, size_t& offset) {
+    int value = 0;
+    int position = 0;
+    while (true) {
+        const uint8_t currentByte = readByte(buffer, offset);
+        value |= (currentByte & SEGMENT_BITS) << position;
+        if ((currentByte & CONTINUE_BIT) == 0) break;
+        position += 7;
+        if (position >= 32)
+            throw std::runtime_error("VarInt: too many bytes");
+    }
+    return value;
+}
+int64_t     stratos::readVarLong(const ByteVec& buffer, size_t& offset) {
+    int64_t value = 0;
+    int position = 0;
+    while (true) {
+        const uint8_t currentByte = readByte(buffer, offset);
+        value |= static_cast<int64_t>(currentByte & SEGMENT_BITS) << position;
+        if ((currentByte & CONTINUE_BIT) == 0) break;
+        position += 7;
+        if (position >= 64)
+            throw std::runtime_error("VarLong is too big");
+    }
+    return value;
+}
+void        stratos::writeVarInt(ByteVec& buffer, int value) {
+    while (true) {
+        if ((value & ~SEGMENT_BITS) == 0) {
+            writeByte(buffer, static_cast<uint8_t>(value));
+            return;
+        }
+        writeByte(buffer, static_cast<uint8_t>((value & SEGMENT_BITS) | CONTINUE_BIT));
+        value = static_cast<uint32_t>(value) >> 7;
+    }
+}
+void stratos::writeVarLong(ByteVec& buffer, int64_t value) {
+    while (true) {
+        if ((value & ~static_cast<int64_t>(SEGMENT_BITS)) == 0) {
+            writeByte(buffer, static_cast<uint8_t>(value));
+            return;
+        }
+        writeByte(buffer, static_cast<uint8_t>((value & SEGMENT_BITS) | CONTINUE_BIT));
+        value = static_cast<uint64_t>(value) >> 7;
+    }
+}
+int stratos::countUTF16CodeUnits(const std::string& utf8) {
+    int count = 0;
+    size_t i = 0;
+
+    while (i < utf8.size()) {
+        unsigned char c = utf8[i];
+
+        if (c < 0x80) {
+            ++i;
+            ++count;
+        } else if ((c >> 5) == 0x6) {
+            i += 2;
+            ++count;
+        } else if ((c >> 4) == 0xE) {
+            i += 3;
+            ++count;
+        } else if ((c >> 3) == 0x1E) {
+            i += 4;
+            count += 2;
+        } else {
+            throw std::runtime_error("Invalid UTF-8 sequence");
+        }
+    }
+
+    return count;
+}

--- a/src/network/protocol/PacketSerialization.cpp
+++ b/src/network/protocol/PacketSerialization.cpp
@@ -19,7 +19,9 @@
 
 #include "PacketSerialization.h"
 
+#include <codecvt>
 #include <cstring>
+#include <locale>
 
 bool stratos::readBoolean(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(bool));
@@ -94,35 +96,51 @@ std::string stratos::readString(const ByteVec& buffer, size_t& offset, const int
 
     return str;
 }
-void stratos::writeBoolean(ByteVec& buffer, const bool& value) {
+std::string stratos::readStringUTF16BE(const ByteVec& buffer, size_t& offset) {
+    if (offset + 2 > buffer.size()) {
+        throw std::out_of_range("StringUTF16BE: not enough bytes for length");
+    }
+    const uint16_t length = static_cast<uint16_t>(buffer[offset++]) << 8 | static_cast<uint16_t>(buffer[offset++]);
+    if (const size_t byteLength = length * 2; offset + byteLength > buffer.size())
+        throw PacketSerializationException("StringUTF16BE: not enough bytes for string content");
+    std::u16string utf16;
+    utf16.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        const char16_t ch = static_cast<char16_t>(buffer[offset++]) << 8 | static_cast<char16_t>(buffer[offset++]);
+        utf16.push_back(ch);
+    }
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+    return convert.to_bytes(utf16);
+}
+void stratos::writeBoolean(ByteVec& buffer, const bool value) {
     buffer.push_back(static_cast<unsigned char>(value ? 1 : 0));
 }
-void stratos::writeByte(ByteVec& buffer, const int8_t& value) {
+void stratos::writeByte(ByteVec& buffer, const int8_t value) {
     buffer.push_back(static_cast<unsigned char>(value));
 }
-void stratos::writeUnsignedByte(ByteVec& buffer, const uint8_t& value) {
+void stratos::writeUnsignedByte(ByteVec& buffer, const uint8_t value) {
     buffer.push_back(value);
 }
-void stratos::writeShort(ByteVec& buffer, const short& value) {
+void stratos::writeShort(ByteVec& buffer, const short value) {
     buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
-void stratos::writeUnsignedShort(ByteVec& buffer, const uint16_t& value) {
+void stratos::writeUnsignedShort(ByteVec& buffer, const uint16_t value) {
     buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
-void stratos::writeInt(ByteVec& buffer, const int& value) {
+void stratos::writeInt(ByteVec& buffer, const int value) {
     buffer.push_back(static_cast<unsigned char>(value >> 24 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value >> 16 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
-void stratos::writeLong(ByteVec& buffer, const int64_t& value) {
+void stratos::writeLong(ByteVec& buffer, const int64_t value) {
     for (int i = 7; i >= 0; --i) {
         buffer.push_back(static_cast<unsigned char>(value >> (i * 8) & 0xFF));
     }
 }
-void stratos::writeFloat(ByteVec& buffer, const float& value) {
+void stratos::writeFloat(ByteVec& buffer, const float value) {
     uint32_t bits;
     std::memcpy(&bits, &value, sizeof(float));
     buffer.push_back(static_cast<unsigned char>(bits >> 24 & 0xFF));
@@ -130,11 +148,11 @@ void stratos::writeFloat(ByteVec& buffer, const float& value) {
     buffer.push_back(static_cast<unsigned char>(bits >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(bits & 0xFF));
 }
-void stratos::writeDouble(ByteVec& buffer, const double& value) {
+void stratos::writeDouble(ByteVec& buffer, const double value) {
     uint64_t bits;
     std::memcpy(&bits, &value, sizeof(double));
     for (int i = 7; i >= 0; --i) {
-        buffer.push_back(static_cast<unsigned char>((bits >> (i * 8)) & 0xFF));
+        buffer.push_back(static_cast<unsigned char>(bits >> (i * 8) & 0xFF));
     }
 }
 void stratos::writeString(ByteVec& buffer, const std::string& value, const int maxChars) {
@@ -149,6 +167,17 @@ void stratos::writeString(ByteVec& buffer, const std::string& value, const int m
     auto length = static_cast<int32_t>(value.size());
     writeVarInt(buffer, length);
     buffer.insert(buffer.end(), value.begin(), value.end());
+}
+void stratos::writeStringUTF16BE(ByteVec& buffer, const std::string& value) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
+    const std::u16string                                              utf16  = convert.from_bytes(value);
+    const auto length = static_cast<uint16_t>(utf16.size());
+    buffer.push_back(length >> 8 & 0xFF); // big-endian
+    buffer.push_back(length & 0xFF);
+    for (const char16_t& ch : utf16) {
+        buffer.push_back(ch >> 8 & 0xFF);  // high byte
+        buffer.push_back(ch & 0xFF);         // low byte
+    }
 }
 int stratos::readVarInt(const ByteVec& buffer, size_t& offset) {
     int value    = 0;
@@ -207,24 +236,24 @@ template <typename T> bool stratos::readPrefixedOptionalX(const ByteVec& buffer,
     if (isPresent) readValue = readFunc(buffer, offset);
     return isPresent;
 }
-template <typename T> std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count) {
+template <typename T> std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count) {
     std::vector<T> result;
     result.reserve(count);
     for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset));
     return result;
 }
 template <typename T>
-std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length) {
+std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length) {
     std::vector<T> result;
     result.reserve(count);
     for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset, length));
     return result;
 }
-template <typename T> std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc) {
+template <typename T> std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc) {
     return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset));
 }
 template <typename T>
-std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, const int length) {
+std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, const int length) {
     return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset), length);
 }
 template <typename T, typename U>
@@ -243,7 +272,7 @@ stratos::ByteVec stratos::readByteArray(const ByteVec& buffer, size_t& offset, c
     for (size_t i = 0; i < length; ++i) result.push_back(readByte(buffer, offset));
     return result;
 }
-void stratos::writeVarInt(ByteVec& buffer, int& value) {
+void stratos::writeVarInt(ByteVec& buffer, int value) {
     while (true) {
         if ((value & ~SEGMENT_BITS) == 0) {
             writeByte(buffer, static_cast<uint8_t>(value));
@@ -253,7 +282,7 @@ void stratos::writeVarInt(ByteVec& buffer, int& value) {
         value = static_cast<uint32_t>(value) >> 7;
     }
 }
-void stratos::writeVarLong(ByteVec& buffer, int64_t& value) {
+void stratos::writeVarLong(ByteVec& buffer, int64_t value) {
     while (true) {
         if ((value & ~static_cast<int64_t>(SEGMENT_BITS)) == 0) {
             writeByte(buffer, static_cast<uint8_t>(value));
@@ -264,7 +293,7 @@ void stratos::writeVarLong(ByteVec& buffer, int64_t& value) {
     }
 }
 void stratos::writeBitSet(ByteVec& buffer, const std::vector<uint64_t>& longs) {
-    int length = static_cast<int>(longs.size());
+    const int length = static_cast<int>(longs.size());
     writeVarInt(buffer, length);
     for (const uint64_t value : longs) {
         for (int i = 7; i >= 0; --i) buffer.push_back(value >> (i * 8) & 0xFF);
@@ -333,13 +362,13 @@ int stratos::countUTF16CodeUnits(const std::string& utf8) {
         if (c < 0x80) {
             ++i;
             ++count;
-        } else if ((c >> 5) == 0x6) {
+        } else if (c >> 5 == 0x6) {
             i += 2;
             ++count;
-        } else if ((c >> 4) == 0xE) {
+        } else if (c >> 4 == 0xE) {
             i += 3;
             ++count;
-        } else if ((c >> 3) == 0x1E) {
+        } else if (c >> 3 == 0x1E) {
             i += 4;
             count += 2;
         } else {

--- a/src/network/protocol/PacketSerialization.cpp
+++ b/src/network/protocol/PacketSerialization.cpp
@@ -21,34 +21,34 @@
 
 #include <cstring>
 
-bool        stratos::readBoolean(const ByteVec& buffer, size_t& offset) {
+bool stratos::readBoolean(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(bool));
     const bool value = buffer[offset++] != 0;
     return value;
 }
-int8_t      stratos::readByte(const ByteVec& buffer, size_t& offset) {
+int8_t stratos::readByte(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(int8_t));
     const auto value = static_cast<int8_t>(buffer[offset++]);
     return value;
 }
-uint8_t     stratos::readUnsignedByte(const ByteVec& buffer, size_t& offset) {
+uint8_t stratos::readUnsignedByte(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(uint8_t));
     const auto value = static_cast<uint8_t>(buffer[offset++]);
     return value;
 }
-short       stratos::readShort(const ByteVec& buffer, size_t& offset) {
+short stratos::readShort(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(short));
     const auto high = static_cast<int16_t>(buffer[offset++]);
     const auto low  = static_cast<int16_t>(buffer[offset++]);
     return static_cast<short>(high << 8 | low & 0xFF);
 }
-uint16_t    stratos::readUnsignedShort(const ByteVec& buffer, size_t& offset) {
+uint16_t stratos::readUnsignedShort(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(uint16_t));
     const auto high = static_cast<uint16_t>(buffer[offset++]);
     const auto low  = static_cast<uint16_t>(buffer[offset++]);
     return static_cast<uint16_t>(high << 8 | low & 0xFF);
 }
-int         stratos::readInt(const ByteVec& buffer, size_t& offset) {
+int stratos::readInt(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(int));
     const auto b1 = static_cast<int32_t>(buffer[offset++]);
     const auto b2 = static_cast<int32_t>(buffer[offset++]);
@@ -56,7 +56,7 @@ int         stratos::readInt(const ByteVec& buffer, size_t& offset) {
     const auto b4 = static_cast<int32_t>(buffer[offset++]);
     return b1 << 24 | b2 << 16 | b3 << 8 | b4 & 0xFF;
 }
-int64_t        stratos::readLong(const ByteVec& buffer, size_t& offset) {
+int64_t stratos::readLong(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(long));
     int64_t result = 0;
     for (int i = 0; i < 8; ++i) {
@@ -64,21 +64,18 @@ int64_t        stratos::readLong(const ByteVec& buffer, size_t& offset) {
     }
     return result;
 }
-float       stratos::readFloat(const ByteVec& buffer, size_t& offset) {
+float stratos::readFloat(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(float));
-    const uint32_t bits = static_cast<uint32_t>(buffer[offset]) << 24 |
-                    static_cast<uint32_t>(buffer[offset + 1]) << 16 |
-                    static_cast<uint32_t>(buffer[offset + 2]) << 8 |
-                    static_cast<uint32_t>(buffer[offset + 3]);
+    const uint32_t bits = static_cast<uint32_t>(buffer[offset]) << 24 | static_cast<uint32_t>(buffer[offset + 1]) << 16 | static_cast<uint32_t>(buffer[offset + 2]) << 8 |
+                          static_cast<uint32_t>(buffer[offset + 3]);
     offset += 4;
     float value;
     std::memcpy(&value, &bits, sizeof(float));
     return value;
 }
-double      stratos::readDouble(const ByteVec& buffer, size_t& offset) {
+double stratos::readDouble(const ByteVec& buffer, size_t& offset) {
     uint64_t bits = 0;
-    for (int i = 0; i < 8; ++i)
-        bits |= static_cast<uint64_t>(buffer[offset++]) << ((7 - i) * 8);
+    for (int i = 0; i < 8; ++i) bits |= static_cast<uint64_t>(buffer[offset++]) << ((7 - i) * 8);
     double value;
     std::memcpy(&value, &bits, sizeof(double));
     return value;
@@ -86,10 +83,8 @@ double      stratos::readDouble(const ByteVec& buffer, size_t& offset) {
 std::string stratos::readString(const ByteVec& buffer, size_t& offset, const int maxChars) {
     const uint32_t length = readVarInt(buffer, offset);
 
-    if (length > maxChars * 3)
-        throw PacketSerializationException("String: length exceeds UTF-8 byte size limit");
-    if (offset + length > buffer.size())
-        throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
+    if (length > maxChars * 3) throw PacketSerializationException("String: length exceeds UTF-8 byte size limit");
+    if (offset + length > buffer.size()) throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
 
     std::string str(buffer.begin() + offset, buffer.begin() + offset + length);
     offset += length;
@@ -99,35 +94,35 @@ std::string stratos::readString(const ByteVec& buffer, size_t& offset, const int
 
     return str;
 }
-void        stratos::writeBoolean(ByteVec& buffer, const bool& value) {
+void stratos::writeBoolean(ByteVec& buffer, const bool& value) {
     buffer.push_back(static_cast<unsigned char>(value ? 1 : 0));
 }
-void        stratos::writeByte(ByteVec& buffer, const int8_t& value) {
+void stratos::writeByte(ByteVec& buffer, const int8_t& value) {
     buffer.push_back(static_cast<unsigned char>(value));
 }
-void        stratos::writeUnsignedByte(ByteVec& buffer, const uint8_t& value) {
+void stratos::writeUnsignedByte(ByteVec& buffer, const uint8_t& value) {
     buffer.push_back(value);
 }
-void        stratos::writeShort(ByteVec& buffer, const short& value) {
+void stratos::writeShort(ByteVec& buffer, const short& value) {
     buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
-void        stratos::writeUnsignedShort(ByteVec& buffer, const uint16_t& value) {
+void stratos::writeUnsignedShort(ByteVec& buffer, const uint16_t& value) {
     buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
-void        stratos::writeInt(ByteVec& buffer, const int& value) {
+void stratos::writeInt(ByteVec& buffer, const int& value) {
     buffer.push_back(static_cast<unsigned char>(value >> 24 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value >> 16 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
-void        stratos::writeLong(ByteVec& buffer, const int64_t& value) {
+void stratos::writeLong(ByteVec& buffer, const int64_t& value) {
     for (int i = 7; i >= 0; --i) {
         buffer.push_back(static_cast<unsigned char>(value >> (i * 8) & 0xFF));
     }
 }
-void        stratos::writeFloat(ByteVec& buffer, const float& value) {
+void stratos::writeFloat(ByteVec& buffer, const float& value) {
     uint32_t bits;
     std::memcpy(&bits, &value, sizeof(float));
     buffer.push_back(static_cast<unsigned char>(bits >> 24 & 0xFF));
@@ -135,14 +130,14 @@ void        stratos::writeFloat(ByteVec& buffer, const float& value) {
     buffer.push_back(static_cast<unsigned char>(bits >> 8 & 0xFF));
     buffer.push_back(static_cast<unsigned char>(bits & 0xFF));
 }
-void        stratos::writeDouble(ByteVec& buffer, const double& value) {
+void stratos::writeDouble(ByteVec& buffer, const double& value) {
     uint64_t bits;
     std::memcpy(&bits, &value, sizeof(double));
     for (int i = 7; i >= 0; --i) {
         buffer.push_back(static_cast<unsigned char>((bits >> (i * 8)) & 0xFF));
     }
 }
-void        stratos::writeString(ByteVec& buffer, const std::string& value, const int maxChars) {
+void stratos::writeString(ByteVec& buffer, const std::string& value, const int maxChars) {
     if (const int utf16Units = countUTF16CodeUnits(value); utf16Units > maxChars) {
         throw PacketSerializationException("String: exceeds character limit");
     }
@@ -151,36 +146,104 @@ void        stratos::writeString(ByteVec& buffer, const std::string& value, cons
         throw PacketSerializationException("String: exceeds UTF-8 byte size limit");
     }
 
-    writeVarInt(buffer, static_cast<uint32_t>(value.size()));
+    auto length = static_cast<int32_t>(value.size());
+    writeVarInt(buffer, length);
     buffer.insert(buffer.end(), value.begin(), value.end());
 }
-int         stratos::readVarInt(const ByteVec& buffer, size_t& offset) {
-    int value = 0;
+int stratos::readVarInt(const ByteVec& buffer, size_t& offset) {
+    int value    = 0;
     int position = 0;
     while (true) {
         const uint8_t currentByte = readByte(buffer, offset);
         value |= (currentByte & SEGMENT_BITS) << position;
         if ((currentByte & CONTINUE_BIT) == 0) break;
         position += 7;
-        if (position >= 32)
-            throw std::runtime_error("VarInt: too many bytes");
+        if (position >= 32) throw PacketSerializationException("VarInt: too many bytes");
     }
     return value;
 }
-int64_t     stratos::readVarLong(const ByteVec& buffer, size_t& offset) {
-    int64_t value = 0;
-    int position = 0;
+int64_t stratos::readVarLong(const ByteVec& buffer, size_t& offset) {
+    int64_t value    = 0;
+    int     position = 0;
     while (true) {
         const uint8_t currentByte = readByte(buffer, offset);
         value |= static_cast<int64_t>(currentByte & SEGMENT_BITS) << position;
         if ((currentByte & CONTINUE_BIT) == 0) break;
         position += 7;
-        if (position >= 64)
-            throw std::runtime_error("VarLong is too big");
+        if (position >= 64) throw PacketSerializationException("VarLong is too big");
     }
     return value;
 }
-void        stratos::writeVarInt(ByteVec& buffer, int value) {
+std::vector<uint64_t> stratos::readBitSet(const ByteVec& buffer, size_t& offset) {
+    const uint32_t        length = readVarInt(buffer, offset);
+    std::vector<uint64_t> longs(length);
+    for (uint32_t i = 0; i < length; ++i) {
+        if (offset + 7 >= buffer.size()) throw PacketSerializationException("BitSet: buffer underflow");
+        uint64_t value = 0;
+        for (int j = 0; j < 8; ++j) value |= static_cast<uint64_t>(buffer[offset++]) << ((7 - j) * 8);
+        longs[i] = value;
+    }
+    return longs;
+}
+std::vector<bool> stratos::readFixedBitSet(const ByteVec& buffer, size_t& offset, const size_t length) {
+    const size_t byteLength = (length + 7) / 8;
+    if (offset + byteLength > buffer.size()) throw PacketSerializationException("FixedBitSet: buffer underflow");
+    std::vector<bool> bits(length);
+    for (size_t i = 0; i < length; ++i) {
+        const uint8_t byte = buffer[offset + i / 8];
+        bits[i]            = (byte >> (i % 8)) & 1;
+    }
+    offset += byteLength;
+    return bits;
+}
+template <typename T>
+bool stratos::readOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue, const bool isPresent) {
+    if (!isPresent) return false;
+    readValue = &readFunc(buffer, offset);
+    return true;
+}
+template <typename T> bool stratos::readPrefixedOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue) {
+    const bool isPresent = readBoolean(buffer, offset);
+    if (isPresent) readValue = readFunc(buffer, offset);
+    return isPresent;
+}
+template <typename T> std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count) {
+    std::vector<T> result;
+    result.reserve(count);
+    for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset));
+    return result;
+}
+template <typename T>
+std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length) {
+    std::vector<T> result;
+    result.reserve(count);
+    for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset, length));
+    return result;
+}
+template <typename T> std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc) {
+    return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset));
+}
+template <typename T>
+std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, const int length) {
+    return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset), length);
+}
+template <typename T, typename U>
+U stratos::readXEnum(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter) {
+    T value = readFunc(buffer, offset);
+    return enumConverter(value);
+}
+template <typename T> std::vector<T> stratos::readEnumSet(const ByteVec& buffer, size_t& offset, const std::function<T(const bool& bit)>& enumConverter, const size_t length) {
+    std::vector<T> result;
+    for (bool bit : readFixedBitSet(buffer, offset, length)) result.push_back(enumConverter(bit));
+    return result;
+}
+stratos::ByteVec stratos::readByteArray(const ByteVec& buffer, size_t& offset, const size_t length) {
+    ByteVec result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) result.push_back(readByte(buffer, offset));
+    return result;
+}
+void stratos::writeVarInt(ByteVec& buffer, int& value) {
     while (true) {
         if ((value & ~SEGMENT_BITS) == 0) {
             writeByte(buffer, static_cast<uint8_t>(value));
@@ -190,7 +253,7 @@ void        stratos::writeVarInt(ByteVec& buffer, int value) {
         value = static_cast<uint32_t>(value) >> 7;
     }
 }
-void stratos::writeVarLong(ByteVec& buffer, int64_t value) {
+void stratos::writeVarLong(ByteVec& buffer, int64_t& value) {
     while (true) {
         if ((value & ~static_cast<int64_t>(SEGMENT_BITS)) == 0) {
             writeByte(buffer, static_cast<uint8_t>(value));
@@ -200,9 +263,69 @@ void stratos::writeVarLong(ByteVec& buffer, int64_t value) {
         value = static_cast<uint64_t>(value) >> 7;
     }
 }
+void stratos::writeBitSet(ByteVec& buffer, const std::vector<uint64_t>& longs) {
+    int length = static_cast<int>(longs.size());
+    writeVarInt(buffer, length);
+    for (const uint64_t value : longs) {
+        for (int i = 7; i >= 0; --i) buffer.push_back(value >> (i * 8) & 0xFF);
+    }
+}
+void stratos::writeFixedBitSet(ByteVec& buffer, const std::vector<bool>& bits, const size_t length) {
+    const size_t byteLength = (length + 7) / 8;
+    for (size_t byteIndex = 0; byteIndex < byteLength; ++byteIndex) {
+        uint8_t byte = 0;
+        for (int bit = 0; bit < 8; ++bit)
+            if (const size_t bitIndex = byteIndex * 8 + bit; bitIndex < bits.size() && bits[bitIndex]) byte |= 1 << bit;
+        buffer.push_back(byte);
+    }
+}
+template <typename T> void stratos::writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc, const bool isPresent) {
+    if (!isPresent || value == nullptr) return;
+    writeFunc(buffer, *value);
+}
+template <typename T>
+void stratos::writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, const bool isPresent, const int length) {
+    if (!isPresent || value == nullptr) return;
+    writeFunc(buffer, *value, length);
+}
+template <typename T> void stratos::writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc) {
+    const bool present = value != nullptr;
+    writeBoolean(buffer, present);
+    if (!present) return;
+    writeFunc(buffer, *value);
+}
+template <typename T> void stratos::writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, const int length) {
+    const bool present = value != nullptr;
+    writeBoolean(buffer, present);
+    if (!present) return;
+    writeFunc(buffer, *value, length);
+}
+template <typename T> void stratos::writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc) {
+    for (const auto& value : values) {
+        writeFunc(buffer, value);
+    }
+}
+template <typename T> void stratos::writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&, int)>& writeFunc, int length) {
+    for (const auto& value : values) {
+        writeFunc(buffer, value, length);
+    }
+}
+template <typename T> void stratos::writePrefixedArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc) {
+    writeVarInt(buffer, static_cast<int>(values.size()));
+    writeArrayOfX(buffer, values, writeFunc);
+}
+template <typename T> void stratos::writeXEnum(ByteVec& buffer, const T& value, const std::function<void(ByteVec&, const T&)>& writeFunc) {
+    writeFunc(buffer, value);
+}
+template <typename T> void stratos::writeXEnum(ByteVec& buffer, const T& value, void (*writeFunc)(ByteVec&, const T&, const int&), const int length) {
+    writeFunc(buffer, value, length);
+}
+void stratos::writeByteArray(ByteVec& buffer, const ByteVec& values) {
+    for (const auto& value : values) buffer.push_back(value);
+}
 int stratos::countUTF16CodeUnits(const std::string& utf8) {
-    int count = 0;
-    size_t i = 0;
+    int    count = 0;
+    size_t i     = 0;
 
     while (i < utf8.size()) {
         unsigned char c = utf8[i];

--- a/src/network/protocol/PacketSerialization.cpp
+++ b/src/network/protocol/PacketSerialization.cpp
@@ -61,9 +61,7 @@ int stratos::readInt(const ByteVec& buffer, size_t& offset) {
 int64_t stratos::readLong(const ByteVec& buffer, size_t& offset) {
     isReadable(buffer, offset, sizeof(long));
     int64_t result = 0;
-    for (int i = 0; i < 8; ++i) {
-        result |= static_cast<int64_t>(buffer[offset++]) << ((7 - i) * 8);
-    }
+    for (int i = 0; i < 8; ++i) result |= static_cast<int64_t>(buffer[offset++]) << ((7 - i) * 8);
     return result;
 }
 float stratos::readFloat(const ByteVec& buffer, size_t& offset) {
@@ -84,25 +82,17 @@ double stratos::readDouble(const ByteVec& buffer, size_t& offset) {
 }
 std::string stratos::readString(const ByteVec& buffer, size_t& offset, const int maxChars) {
     const uint32_t length = readVarInt(buffer, offset);
-
     if (length > maxChars * 3) throw PacketSerializationException("String: length exceeds UTF-8 byte size limit");
     if (offset + length > buffer.size()) throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
-
     std::string str(buffer.begin() + offset, buffer.begin() + offset + length);
     offset += length;
-    if (const int utf16Units = countUTF16CodeUnits(str); utf16Units > maxChars) {
-        throw PacketSerializationException("String: character length exceeds maximum");
-    }
-
+    if (const int utf16Units = countUTF16CodeUnits(str); utf16Units > maxChars) throw PacketSerializationException("String: character length exceeds maximum");
     return str;
 }
 std::string stratos::readStringUTF16BE(const ByteVec& buffer, size_t& offset) {
-    if (offset + 2 > buffer.size()) {
-        throw std::out_of_range("StringUTF16BE: not enough bytes for length");
-    }
+    if (offset + 2 > buffer.size()) throw std::out_of_range("StringUTF16BE: not enough bytes for length");
     const uint16_t length = static_cast<uint16_t>(buffer[offset++]) << 8 | static_cast<uint16_t>(buffer[offset++]);
-    if (const size_t byteLength = length * 2; offset + byteLength > buffer.size())
-        throw PacketSerializationException("StringUTF16BE: not enough bytes for string content");
+    if (const size_t byteLength = length * 2; offset + byteLength > buffer.size()) throw PacketSerializationException("StringUTF16BE: not enough bytes for string content");
     std::u16string utf16;
     utf16.reserve(length);
     for (size_t i = 0; i < length; ++i) {
@@ -136,9 +126,7 @@ void stratos::writeInt(ByteVec& buffer, const int value) {
     buffer.push_back(static_cast<unsigned char>(value & 0xFF));
 }
 void stratos::writeLong(ByteVec& buffer, const int64_t value) {
-    for (int i = 7; i >= 0; --i) {
-        buffer.push_back(static_cast<unsigned char>(value >> (i * 8) & 0xFF));
-    }
+    for (int i = 7; i >= 0; --i) buffer.push_back(static_cast<unsigned char>(value >> (i * 8) & 0xFF));
 }
 void stratos::writeFloat(ByteVec& buffer, const float value) {
     uint32_t bits;
@@ -151,32 +139,24 @@ void stratos::writeFloat(ByteVec& buffer, const float value) {
 void stratos::writeDouble(ByteVec& buffer, const double value) {
     uint64_t bits;
     std::memcpy(&bits, &value, sizeof(double));
-    for (int i = 7; i >= 0; --i) {
-        buffer.push_back(static_cast<unsigned char>(bits >> (i * 8) & 0xFF));
-    }
+    for (int i = 7; i >= 0; --i) buffer.push_back(static_cast<unsigned char>(bits >> (i * 8) & 0xFF));
 }
 void stratos::writeString(ByteVec& buffer, const std::string& value, const int maxChars) {
-    if (const int utf16Units = countUTF16CodeUnits(value); utf16Units > maxChars) {
-        throw PacketSerializationException("String: exceeds character limit");
-    }
-
-    if (value.size() > maxChars * 3) {
-        throw PacketSerializationException("String: exceeds UTF-8 byte size limit");
-    }
-
-    auto length = static_cast<int32_t>(value.size());
+    if (const int utf16Units = countUTF16CodeUnits(value); utf16Units > maxChars) throw PacketSerializationException("String: exceeds character limit");
+    if (value.size() > maxChars * 3) throw PacketSerializationException("String: exceeds UTF-8 byte size limit");
+    const auto length = static_cast<int32_t>(value.size());
     writeVarInt(buffer, length);
     buffer.insert(buffer.end(), value.begin(), value.end());
 }
 void stratos::writeStringUTF16BE(ByteVec& buffer, const std::string& value) {
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     const std::u16string                                              utf16  = convert.from_bytes(value);
-    const auto length = static_cast<uint16_t>(utf16.size());
+    const auto                                                        length = static_cast<uint16_t>(utf16.size());
     buffer.push_back(length >> 8 & 0xFF); // big-endian
     buffer.push_back(length & 0xFF);
     for (const char16_t& ch : utf16) {
-        buffer.push_back(ch >> 8 & 0xFF);  // high byte
-        buffer.push_back(ch & 0xFF);         // low byte
+        buffer.push_back(ch >> 8 & 0xFF); // high byte
+        buffer.push_back(ch & 0xFF);      // low byte
     }
 }
 int stratos::readVarInt(const ByteVec& buffer, size_t& offset) {
@@ -225,47 +205,6 @@ std::vector<bool> stratos::readFixedBitSet(const ByteVec& buffer, size_t& offset
     offset += byteLength;
     return bits;
 }
-template <typename T>
-bool stratos::readOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue, const bool isPresent) {
-    if (!isPresent) return false;
-    readValue = &readFunc(buffer, offset);
-    return true;
-}
-template <typename T> bool stratos::readPrefixedOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue) {
-    const bool isPresent = readBoolean(buffer, offset);
-    if (isPresent) readValue = readFunc(buffer, offset);
-    return isPresent;
-}
-template <typename T> std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count) {
-    std::vector<T> result;
-    result.reserve(count);
-    for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset));
-    return result;
-}
-template <typename T>
-std::vector<T> stratos::readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length) {
-    std::vector<T> result;
-    result.reserve(count);
-    for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset, length));
-    return result;
-}
-template <typename T> std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc) {
-    return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset));
-}
-template <typename T>
-std::vector<T> stratos::readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, const int length) {
-    return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset), length);
-}
-template <typename T, typename U>
-U stratos::readXEnum(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter) {
-    T value = readFunc(buffer, offset);
-    return enumConverter(value);
-}
-template <typename T> std::vector<T> stratos::readEnumSet(const ByteVec& buffer, size_t& offset, const std::function<T(const bool& bit)>& enumConverter, const size_t length) {
-    std::vector<T> result;
-    for (bool bit : readFixedBitSet(buffer, offset, length)) result.push_back(enumConverter(bit));
-    return result;
-}
 stratos::ByteVec stratos::readByteArray(const ByteVec& buffer, size_t& offset, const size_t length) {
     ByteVec result;
     result.reserve(length);
@@ -295,9 +234,8 @@ void stratos::writeVarLong(ByteVec& buffer, int64_t value) {
 void stratos::writeBitSet(ByteVec& buffer, const std::vector<uint64_t>& longs) {
     const int length = static_cast<int>(longs.size());
     writeVarInt(buffer, length);
-    for (const uint64_t value : longs) {
+    for (const uint64_t value : longs)
         for (int i = 7; i >= 0; --i) buffer.push_back(value >> (i * 8) & 0xFF);
-    }
 }
 void stratos::writeFixedBitSet(ByteVec& buffer, const std::vector<bool>& bits, const size_t length) {
     const size_t byteLength = (length + 7) / 8;
@@ -308,58 +246,14 @@ void stratos::writeFixedBitSet(ByteVec& buffer, const std::vector<bool>& bits, c
         buffer.push_back(byte);
     }
 }
-template <typename T> void stratos::writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc, const bool isPresent) {
-    if (!isPresent || value == nullptr) return;
-    writeFunc(buffer, *value);
-}
-template <typename T>
-void stratos::writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, const bool isPresent, const int length) {
-    if (!isPresent || value == nullptr) return;
-    writeFunc(buffer, *value, length);
-}
-template <typename T> void stratos::writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc) {
-    const bool present = value != nullptr;
-    writeBoolean(buffer, present);
-    if (!present) return;
-    writeFunc(buffer, *value);
-}
-template <typename T> void stratos::writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, const int length) {
-    const bool present = value != nullptr;
-    writeBoolean(buffer, present);
-    if (!present) return;
-    writeFunc(buffer, *value, length);
-}
-template <typename T> void stratos::writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc) {
-    for (const auto& value : values) {
-        writeFunc(buffer, value);
-    }
-}
-template <typename T> void stratos::writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&, int)>& writeFunc, int length) {
-    for (const auto& value : values) {
-        writeFunc(buffer, value, length);
-    }
-}
-template <typename T> void stratos::writePrefixedArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc) {
-    writeVarInt(buffer, static_cast<int>(values.size()));
-    writeArrayOfX(buffer, values, writeFunc);
-}
-template <typename T> void stratos::writeXEnum(ByteVec& buffer, const T& value, const std::function<void(ByteVec&, const T&)>& writeFunc) {
-    writeFunc(buffer, value);
-}
-template <typename T> void stratos::writeXEnum(ByteVec& buffer, const T& value, void (*writeFunc)(ByteVec&, const T&, const int&), const int length) {
-    writeFunc(buffer, value, length);
-}
 void stratos::writeByteArray(ByteVec& buffer, const ByteVec& values) {
     for (const auto& value : values) buffer.push_back(value);
 }
 int stratos::countUTF16CodeUnits(const std::string& utf8) {
     int    count = 0;
     size_t i     = 0;
-
     while (i < utf8.size()) {
-        unsigned char c = utf8[i];
-
-        if (c < 0x80) {
+        if (const unsigned char c = utf8[i]; c < 0x80) {
             ++i;
             ++count;
         } else if (c >> 5 == 0x6) {
@@ -375,6 +269,5 @@ int stratos::countUTF16CodeUnits(const std::string& utf8) {
             throw std::runtime_error("Invalid UTF-8 sequence");
         }
     }
-
     return count;
 }

--- a/src/network/protocol/PacketSerialization.h
+++ b/src/network/protocol/PacketSerialization.h
@@ -45,17 +45,19 @@ int64_t     readLong(const ByteVec& buffer, size_t& offset);
 float       readFloat(const ByteVec& buffer, size_t& offset);
 double      readDouble(const ByteVec& buffer, size_t& offset);
 std::string readString(const ByteVec& buffer, size_t& offset, int maxChars);
+std::string readStringUTF16BE(const ByteVec& buffer, size_t& offset);
 
-void writeBoolean(ByteVec& buffer, const bool& value);
-void writeByte(ByteVec& buffer, const int8_t& value);
-void writeUnsignedByte(ByteVec& buffer, const uint8_t& value);
-void writeShort(ByteVec& buffer, const short& value);
-void writeUnsignedShort(ByteVec& buffer, const uint16_t& value);
-void writeInt(ByteVec& buffer, const int& value);
-void writeLong(ByteVec& buffer, const int64_t& value);
-void writeFloat(ByteVec& buffer, const float& value);
-void writeDouble(ByteVec& buffer, const double& value);
+void writeBoolean(ByteVec& buffer, bool value);
+void writeByte(ByteVec& buffer, int8_t value);
+void writeUnsignedByte(ByteVec& buffer, uint8_t value);
+void writeShort(ByteVec& buffer, short value);
+void writeUnsignedShort(ByteVec& buffer, uint16_t value);
+void writeInt(ByteVec& buffer, int value);
+void writeLong(ByteVec& buffer, int64_t value);
+void writeFloat(ByteVec& buffer, float value);
+void writeDouble(ByteVec& buffer, double value);
 void writeString(ByteVec& buffer, const std::string& value, int maxChars);
+void writeStringUTF16BE(ByteVec& buffer, const std::string& value);
 
 // Minecraft type serialization functions
 int constexpr SEGMENT_BITS = 0x7F;
@@ -76,11 +78,11 @@ std::vector<uint64_t>      readBitSet(const ByteVec& buffer, size_t& offset);
 std::vector<bool>          readFixedBitSet(const ByteVec& buffer, size_t& offset, size_t length);
 template <typename T> bool readOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue, bool isPresent = true);
 template <typename T> bool readPrefixedOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue);
-template <typename T> std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count);
+template <typename T> std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count);
 template <typename T>
-std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length);
-template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc);
-template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, int length);
+std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length);
+template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc);
+template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, int length);
 template <typename T, typename U>
 U readXEnum(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter);
 template <typename T> std::vector<T> readEnumSet(const ByteVec& buffer, size_t& offset, const std::function<T(const bool& bit)>& enumConverter, size_t length);
@@ -91,8 +93,8 @@ ByteVec                              readByteArray(const ByteVec& buffer, size_t
 // TODO: readChatType
 // TODO: readChunkData ??
 // TODO: readLightData ??
-void writeVarInt(ByteVec& buffer, int& value);
-void writeVarLong(ByteVec& buffer, int64_t& value);
+void writeVarInt(ByteVec& buffer, int value);
+void writeVarLong(ByteVec& buffer, int64_t value);
 // TODO: writeTextComponent
 // TODO: writeJSONTextComponent
 // TODO: writeIdentifier
@@ -162,28 +164,38 @@ class PacketBuffer {
     float                 readFloat() { return stratos::readFloat(buffer, offset); }
     double                readDouble() { return stratos::readDouble(buffer, offset); }
     std::string           readString(const int maxChars) { return stratos::readString(buffer, offset, maxChars); }
+    std::string           readStringUTF16BE() { return stratos::readStringUTF16BE(buffer, offset); }
     int                   readVarInt() { return stratos::readVarInt(buffer, offset); }
     int64_t               readVarLong() { return stratos::readVarLong(buffer, offset); }
     std::vector<uint64_t> readBitSet() { return stratos::readBitSet(buffer, offset); }
     std::vector<bool>     readFixedBitSet(const size_t length) { return stratos::readFixedBitSet(buffer, offset, length); }
     // TODO: Read array of X, optional X, and so on get individual methods per type
+    template <typename T, typename U>
+    U readXEnum(const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter) {
+        return stratos::readXEnum<T, U>(buffer, offset, readFunc, enumConverter);
+    }
     ByteVec readByteArray(const size_t length) { return stratos::readByteArray(buffer, offset, length); }
 
-    void writeBoolean(const bool& value) { stratos::writeBoolean(buffer, value); }
-    void writeByte(const int8_t& value) { stratos::writeByte(buffer, value); }
-    void writeUnsignedByte(const uint8_t& value) { stratos::writeUnsignedByte(buffer, value); }
-    void writeShort(const short& value) { stratos::writeShort(buffer, value); }
-    void writeUnsignedShort(const uint16_t& value) { stratos::writeUnsignedShort(buffer, value); }
-    void writeInt(const int& value) { stratos::writeInt(buffer, value); }
-    void writeLong(const int64_t& value) { stratos::writeLong(buffer, value); }
-    void writeFloat(const float& value) { stratos::writeFloat(buffer, value); }
-    void writeDouble(const double& value) { stratos::writeDouble(buffer, value); }
+    void writeBoolean(const bool value) { stratos::writeBoolean(buffer, value); }
+    void writeByte(const int8_t value) { stratos::writeByte(buffer, value); }
+    void writeUnsignedByte(const uint8_t value) { stratos::writeUnsignedByte(buffer, value); }
+    void writeShort(const short value) { stratos::writeShort(buffer, value); }
+    void writeUnsignedShort(const uint16_t value) { stratos::writeUnsignedShort(buffer, value); }
+    void writeInt(const int value) { stratos::writeInt(buffer, value); }
+    void writeLong(const int64_t value) { stratos::writeLong(buffer, value); }
+    void writeFloat(const float value) { stratos::writeFloat(buffer, value); }
+    void writeDouble(const double value) { stratos::writeDouble(buffer, value); }
     void writeString(const std::string& value, const int maxChars) { stratos::writeString(buffer, value, maxChars); }
-    void writeVarInt(int& value) { stratos::writeVarInt(buffer, value); }
-    void writeVarLong(int64_t& value) { stratos::writeVarLong(buffer, value); }
+    void writeStringUTF16BE(const std::string& value) { stratos::writeStringUTF16BE(buffer, value); }
+    void writeVarInt(int value) { stratos::writeVarInt(buffer, value); }
+    void writeVarLong(int64_t value) { stratos::writeVarLong(buffer, value); }
     void writeBitSet(const std::vector<uint64_t>& longs) { stratos::writeBitSet(buffer, longs); }
     void writeFixedBitSet(const std::vector<bool>& bits, const size_t length) { stratos::writeFixedBitSet(buffer, bits, length); }
     // TODO: Write array of X, optional X, and so on get individual methods per type
+    template <typename T>
+    void writeXEnum(const T& value, const std::function<void(ByteVec&, const T&)>& writeFunc) {
+        stratos::writeXEnum<T>(buffer, value, writeFunc);
+    }
     void writeByteArray(const ByteVec& values) { stratos::writeByteArray(buffer, values); }
 
     [[nodiscard]] const ByteVec& getBuffer() const { return buffer; }

--- a/src/network/protocol/PacketSerialization.h
+++ b/src/network/protocol/PacketSerialization.h
@@ -1,0 +1,77 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#ifndef PACKETSERIALIZATION_H
+#define PACKETSERIALIZATION_H
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace stratos {
+using ByteVec = std::vector<unsigned char>;
+
+class PacketSerializationException final : public std::logic_error {
+public:
+    explicit PacketSerializationException(const char* message) : logic_error(message) {};
+    explicit PacketSerializationException(const std::string& message) : logic_error(message) {};
+};
+
+// Generic serialization functions
+bool readBoolean(const ByteVec& buffer, size_t& offset);
+int8_t readByte(const ByteVec& buffer, size_t& offset);
+uint8_t readUnsignedByte(const ByteVec& buffer, size_t& offset);
+short readShort(const ByteVec& buffer, size_t& offset);
+uint16_t readUnsignedShort(const ByteVec& buffer, size_t& offset);
+int readInt(const ByteVec& buffer, size_t& offset);
+int64_t readLong(const ByteVec& buffer, size_t& offset);
+float readFloat(const ByteVec& buffer, size_t& offset);
+double readDouble(const ByteVec& buffer, size_t& offset);
+std::string readString(const ByteVec& buffer, size_t& offset, int maxChars);
+
+void writeBoolean(ByteVec& buffer, const bool& value);
+void writeByte(ByteVec& buffer, const int8_t& value);
+void writeUnsignedByte(ByteVec& buffer, const uint8_t& value);
+void writeShort(ByteVec& buffer, const short& value);
+void writeUnsignedShort(ByteVec& buffer, const uint16_t& value);
+void writeInt(ByteVec& buffer, const int& value);
+void writeLong(ByteVec& buffer, const int64_t& value);
+void writeFloat(ByteVec& buffer, const float& value);
+void writeDouble(ByteVec& buffer, const double& value);
+void writeString(ByteVec& buffer, const std::string& value, int maxChars);
+
+// Minecraft type serialization functions
+int constexpr SEGMENT_BITS = 0x7F;
+int constexpr CONTINUE_BIT = 0x80;
+int readVarInt(const ByteVec& buffer, size_t& offset);
+int64_t readVarLong(const ByteVec& buffer, size_t& offset);
+void writeVarInt(ByteVec& buffer, int value);
+void writeVarLong(ByteVec& buffer, int64_t value);
+
+// Helper functions
+inline bool isReadable(const ByteVec& buffer, const size_t& offset, const size_t& bytes) {
+    if (offset + bytes > buffer.size())
+        throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
+
+    return true;
+}
+int countUTF16CodeUnits(const std::string& utf8);
+} // namespace stratos
+
+#endif

--- a/src/network/protocol/PacketSerialization.h
+++ b/src/network/protocol/PacketSerialization.h
@@ -20,7 +20,6 @@
 #ifndef PACKETSERIALIZATION_H
 #define PACKETSERIALIZATION_H
 #include <cstdint>
-#include <functional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -74,19 +73,49 @@ int64_t readVarLong(const ByteVec& buffer, size_t& offset);
 // TODO: readPosition
 // TODO: readAngle
 // TODO: readUUID
-std::vector<uint64_t>      readBitSet(const ByteVec& buffer, size_t& offset);
-std::vector<bool>          readFixedBitSet(const ByteVec& buffer, size_t& offset, size_t length);
-template <typename T> bool readOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue, bool isPresent = true);
-template <typename T> bool readPrefixedOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue);
-template <typename T> std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count);
-template <typename T>
-std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length);
-template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc);
-template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&, int)>& readFunc, int length);
-template <typename T, typename U>
-U readXEnum(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter);
-template <typename T> std::vector<T> readEnumSet(const ByteVec& buffer, size_t& offset, const std::function<T(const bool& bit)>& enumConverter, size_t length);
-ByteVec                              readByteArray(const ByteVec& buffer, size_t& offset, size_t length);
+std::vector<uint64_t> readBitSet(const ByteVec& buffer, size_t& offset);
+std::vector<bool>     readFixedBitSet(const ByteVec& buffer, size_t& offset, size_t length);
+template <typename T, typename ReadFunc> bool readOptionalX(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc, T& readValue, const bool isPresent) {
+    if (!isPresent) return false;
+    readValue = &readFunc(buffer, offset);
+    return true;
+}
+template <typename T, typename ReadFunc> bool readPrefixedOptionalX(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc, T& readValue) {
+    const bool isPresent = readBoolean(buffer, offset);
+    if (isPresent) readValue = readFunc(buffer, offset);
+    return isPresent;
+}
+template <typename T, typename ReadFunc> std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc, size_t count) {
+    std::vector<T> result;
+    result.reserve(count);
+    for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset));
+    return result;
+}
+template <typename T, typename ReadFunc>
+std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc, size_t count, int length) {
+    std::vector<T> result;
+    result.reserve(count);
+    for (size_t i = 0; i < count; ++i) result.push_back(readFunc(buffer, offset, length));
+    return result;
+}
+template <typename T, typename ReadFunc> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc) {
+    return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset));
+}
+template <typename T, typename ReadFunc>
+std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc, const int length) {
+    return readArrayOfX<T>(buffer, offset, readFunc, readVarInt(buffer, offset), length);
+}
+template <typename T, typename U, typename ReadFunc, typename EnumConverter>
+U readXEnum(const ByteVec& buffer, size_t& offset, const ReadFunc& readFunc, const EnumConverter& enumConverter) {
+    T value = readFunc(buffer, offset);
+    return enumConverter(value);
+}
+template <typename T, typename EnumConverter> std::vector<T> readEnumSet(const ByteVec& buffer, size_t& offset, const EnumConverter& enumConverter, const size_t length) {
+    std::vector<T> result;
+    for (bool bit : readFixedBitSet(buffer, offset, length)) result.push_back(enumConverter(bit));
+    return result;
+}
+ByteVec readByteArray(const ByteVec& buffer, size_t& offset, size_t length);
 // TODO: readIDOrX
 // TODO: readIDSet
 // TODO: readSoundEvent
@@ -107,17 +136,49 @@ void writeVarLong(ByteVec& buffer, int64_t value);
 // TODO: writeUUID
 void                       writeBitSet(ByteVec& buffer, const std::vector<uint64_t>& longs);
 void                       writeFixedBitSet(ByteVec& buffer, const std::vector<bool>& bits, size_t length);
-template <typename T> void writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc, bool isPresent = true);
-template <typename T> void writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, bool isPresent = true, int length = 0);
-template <typename T> void writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc);
-template <typename T> void writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, int length);
-template <typename T> void writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc);
-template <typename T> void writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&, int)>& writeFunc, int length);
-template <typename T> void writePrefixedArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc);
-template <typename T> void writeXEnum(ByteVec& buffer, const T& value, const std::function<void(ByteVec&, const T&)>& writeFunc);
-template <typename T> void writeXEnum(ByteVec& buffer, const T& value, void (*writeFunc)(ByteVec&, const T&, const int&), int length);
-void                       writeEnumSet(ByteVec& buffer, const std::vector<bool>& values);
-void                       writeByteArray(ByteVec& buffer, const ByteVec& values);
+template <typename T, typename WriteFunc> void writeOptionalX(ByteVec& buffer, const T* value, const WriteFunc& writeFunc, const bool isPresent) {
+    if (!isPresent || value == nullptr) return;
+    writeFunc(buffer, *value);
+}
+template <typename T, typename WriteFunc>
+void writeOptionalX(ByteVec& buffer, const T* value, const WriteFunc& writeFunc, const bool isPresent, const int length) {
+    if (!isPresent || value == nullptr) return;
+    writeFunc(buffer, *value, length);
+}
+template <typename T, typename WriteFunc> void writePrefixedOptionalX(ByteVec& buffer, const T* value, const WriteFunc& writeFunc) {
+    const bool present = value != nullptr;
+    writeBoolean(buffer, present);
+    if (!present) return;
+    writeFunc(buffer, *value);
+}
+template <typename T, typename WriteFunc> void writePrefixedOptionalX(ByteVec& buffer, const T* value, const WriteFunc& writeFunc, const int length) {
+    const bool present = value != nullptr;
+    writeBoolean(buffer, present);
+    if (!present) return;
+    writeFunc(buffer, *value, length);
+}
+template <typename T, typename WriteFunc> void writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const WriteFunc& writeFunc) {
+    for (const auto& value : values) {
+        writeFunc(buffer, value);
+    }
+}
+template <typename T, typename WriteFunc> void writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const WriteFunc& writeFunc, int length) {
+    for (const auto& value : values) {
+        writeFunc(buffer, value, length);
+    }
+}
+template <typename T, typename WriteFunc> void writePrefixedArrayOfX(ByteVec& buffer, const std::vector<T>& values, const WriteFunc& writeFunc) {
+    writeVarInt(buffer, static_cast<int>(values.size()));
+    writeArrayOfX(buffer, values, writeFunc);
+}
+template <typename T, typename WriteFunc> void writeXEnum(ByteVec& buffer, const T& value, const WriteFunc& writeFunc) {
+    writeFunc(buffer, value);
+}
+template <typename T, typename WriteFunc> void writeXEnum(ByteVec& buffer, const T& value, const WriteFunc& writeFunc, const int length) {
+    writeFunc(buffer, value, length);
+}
+void writeEnumSet(ByteVec& buffer, const std::vector<bool>& values);
+void writeByteArray(ByteVec& buffer, const ByteVec& values);
 // TODO: writeIDOrX
 // TODO: writeIDSet
 // TODO: writeSoundEvent
@@ -141,6 +202,8 @@ class PacketBuffer {
     PacketBuffer() : offset(0) {};
     explicit PacketBuffer(const ByteVec& buffer) : buffer(buffer), offset(0) {};
     explicit PacketBuffer(ByteVec&& buffer) : buffer(std::move(buffer)), offset(0) {};
+    PacketBuffer(const ByteVec& buffer, const int offset) : buffer(buffer), offset(offset) {};
+    PacketBuffer(ByteVec&& buffer, const int offset) : buffer(std::move(buffer)), offset(offset) {};
     PacketBuffer(const PacketBuffer&) = default;
     PacketBuffer(PacketBuffer&&)      = default;
     ~PacketBuffer()                   = default;
@@ -170,8 +233,7 @@ class PacketBuffer {
     std::vector<uint64_t> readBitSet() { return stratos::readBitSet(buffer, offset); }
     std::vector<bool>     readFixedBitSet(const size_t length) { return stratos::readFixedBitSet(buffer, offset, length); }
     // TODO: Read array of X, optional X, and so on get individual methods per type
-    template <typename T, typename U>
-    U readXEnum(const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter) {
+    template <typename T, typename U, typename ReadFunc, typename EnumConverter> U readXEnum(const ReadFunc& readFunc, const EnumConverter& enumConverter) {
         return stratos::readXEnum<T, U>(buffer, offset, readFunc, enumConverter);
     }
     ByteVec readByteArray(const size_t length) { return stratos::readByteArray(buffer, offset, length); }
@@ -192,11 +254,8 @@ class PacketBuffer {
     void writeBitSet(const std::vector<uint64_t>& longs) { stratos::writeBitSet(buffer, longs); }
     void writeFixedBitSet(const std::vector<bool>& bits, const size_t length) { stratos::writeFixedBitSet(buffer, bits, length); }
     // TODO: Write array of X, optional X, and so on get individual methods per type
-    template <typename T>
-    void writeXEnum(const T& value, const std::function<void(ByteVec&, const T&)>& writeFunc) {
-        stratos::writeXEnum<T>(buffer, value, writeFunc);
-    }
-    void writeByteArray(const ByteVec& values) { stratos::writeByteArray(buffer, values); }
+    template <typename T, typename WriteFunc> void writeXEnum(const T& value, const WriteFunc& writeFunc) { stratos::writeXEnum<T>(buffer, value, writeFunc); }
+    void                       writeByteArray(const ByteVec& values) { stratos::writeByteArray(buffer, values); }
 
     [[nodiscard]] const ByteVec& getBuffer() const { return buffer; }
     [[nodiscard]] size_t         getOffset() const { return offset; }

--- a/src/network/protocol/PacketSerialization.h
+++ b/src/network/protocol/PacketSerialization.h
@@ -20,6 +20,7 @@
 #ifndef PACKETSERIALIZATION_H
 #define PACKETSERIALIZATION_H
 #include <cstdint>
+#include <functional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -28,21 +29,21 @@ namespace stratos {
 using ByteVec = std::vector<unsigned char>;
 
 class PacketSerializationException final : public std::logic_error {
-public:
+  public:
     explicit PacketSerializationException(const char* message) : logic_error(message) {};
     explicit PacketSerializationException(const std::string& message) : logic_error(message) {};
 };
 
 // Generic serialization functions
-bool readBoolean(const ByteVec& buffer, size_t& offset);
-int8_t readByte(const ByteVec& buffer, size_t& offset);
-uint8_t readUnsignedByte(const ByteVec& buffer, size_t& offset);
-short readShort(const ByteVec& buffer, size_t& offset);
-uint16_t readUnsignedShort(const ByteVec& buffer, size_t& offset);
-int readInt(const ByteVec& buffer, size_t& offset);
-int64_t readLong(const ByteVec& buffer, size_t& offset);
-float readFloat(const ByteVec& buffer, size_t& offset);
-double readDouble(const ByteVec& buffer, size_t& offset);
+bool        readBoolean(const ByteVec& buffer, size_t& offset);
+int8_t      readByte(const ByteVec& buffer, size_t& offset);
+uint8_t     readUnsignedByte(const ByteVec& buffer, size_t& offset);
+short       readShort(const ByteVec& buffer, size_t& offset);
+uint16_t    readUnsignedShort(const ByteVec& buffer, size_t& offset);
+int         readInt(const ByteVec& buffer, size_t& offset);
+int64_t     readLong(const ByteVec& buffer, size_t& offset);
+float       readFloat(const ByteVec& buffer, size_t& offset);
+double      readDouble(const ByteVec& buffer, size_t& offset);
 std::string readString(const ByteVec& buffer, size_t& offset, int maxChars);
 
 void writeBoolean(ByteVec& buffer, const bool& value);
@@ -59,15 +60,72 @@ void writeString(ByteVec& buffer, const std::string& value, int maxChars);
 // Minecraft type serialization functions
 int constexpr SEGMENT_BITS = 0x7F;
 int constexpr CONTINUE_BIT = 0x80;
-int readVarInt(const ByteVec& buffer, size_t& offset);
+int     readVarInt(const ByteVec& buffer, size_t& offset);
 int64_t readVarLong(const ByteVec& buffer, size_t& offset);
-void writeVarInt(ByteVec& buffer, int value);
-void writeVarLong(ByteVec& buffer, int64_t value);
+// TODO: readTextComponent
+// TODO: readJSONTextComponent
+// TODO: readIdentifier
+// TODO: readEntityMetaData
+// TODO: readSlot
+// TODO: readHashedSlot
+// TODO: readNBT
+// TODO: readPosition
+// TODO: readAngle
+// TODO: readUUID
+std::vector<uint64_t>      readBitSet(const ByteVec& buffer, size_t& offset);
+std::vector<bool>          readFixedBitSet(const ByteVec& buffer, size_t& offset, size_t length);
+template <typename T> bool readOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue, bool isPresent = true);
+template <typename T> bool readPrefixedOptionalX(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, T& readValue);
+template <typename T> std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc, size_t count);
+template <typename T>
+std::vector<T> readArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, size_t count, int length);
+template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&)>& readFunc);
+template <typename T> std::vector<T> readPrefixedArrayOfX(const ByteVec& buffer, size_t& offset, T const std::function<T(const ByteVec&, size_t&, int)>& readFunc, int length);
+template <typename T, typename U>
+U readXEnum(const ByteVec& buffer, size_t& offset, const std::function<T(const ByteVec&, size_t&)>& readFunc, std::function<U(const T&)> enumConverter);
+template <typename T> std::vector<T> readEnumSet(const ByteVec& buffer, size_t& offset, const std::function<T(const bool& bit)>& enumConverter, size_t length);
+ByteVec                              readByteArray(const ByteVec& buffer, size_t& offset, size_t length);
+// TODO: readIDOrX
+// TODO: readIDSet
+// TODO: readSoundEvent
+// TODO: readChatType
+// TODO: readChunkData ??
+// TODO: readLightData ??
+void writeVarInt(ByteVec& buffer, int& value);
+void writeVarLong(ByteVec& buffer, int64_t& value);
+// TODO: writeTextComponent
+// TODO: writeJSONTextComponent
+// TODO: writeIdentifier
+// TODO: writeEntityMetaData
+// TODO: writeSlot
+// TODO: writeHashedSlot
+// TODO: writeNBT
+// TODO: writePosition
+// TODO: writeAngle
+// TODO: writeUUID
+void                       writeBitSet(ByteVec& buffer, const std::vector<uint64_t>& longs);
+void                       writeFixedBitSet(ByteVec& buffer, const std::vector<bool>& bits, size_t length);
+template <typename T> void writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc, bool isPresent = true);
+template <typename T> void writeOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, bool isPresent = true, int length = 0);
+template <typename T> void writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&)>& writeFunc);
+template <typename T> void writePrefixedOptionalX(ByteVec& buffer, const T* value, const std::function<void(ByteVec&, const T&, int)>& writeFunc, int length);
+template <typename T> void writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc);
+template <typename T> void writeArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&, int)>& writeFunc, int length);
+template <typename T> void writePrefixedArrayOfX(ByteVec& buffer, const std::vector<T>& values, const std::function<void(ByteVec&, const T&)>& writeFunc);
+template <typename T> void writeXEnum(ByteVec& buffer, const T& value, const std::function<void(ByteVec&, const T&)>& writeFunc);
+template <typename T> void writeXEnum(ByteVec& buffer, const T& value, void (*writeFunc)(ByteVec&, const T&, const int&), int length);
+void                       writeEnumSet(ByteVec& buffer, const std::vector<bool>& values);
+void                       writeByteArray(ByteVec& buffer, const ByteVec& values);
+// TODO: writeIDOrX
+// TODO: writeIDSet
+// TODO: writeSoundEvent
+// TODO: writeChatType
+// TODO: writeChunkData ??
+// TODO: writeLightData ??
 
 // Helper functions
 inline bool isReadable(const ByteVec& buffer, const size_t& offset, const size_t& bytes) {
-    if (offset + bytes > buffer.size())
-        throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
+    if (offset + bytes > buffer.size()) throw PacketSerializationException("Buffer overflow: Tried reading beyond buffer size.");
 
     return true;
 }
@@ -75,31 +133,41 @@ int countUTF16CodeUnits(const std::string& utf8);
 
 class PacketBuffer {
     ByteVec buffer;
-    size_t offset;
-public:
+    size_t  offset;
+
+  public:
     PacketBuffer() : offset(0) {};
     explicit PacketBuffer(const ByteVec& buffer) : buffer(buffer), offset(0) {};
     explicit PacketBuffer(ByteVec&& buffer) : buffer(std::move(buffer)), offset(0) {};
     PacketBuffer(const PacketBuffer&) = default;
     PacketBuffer(PacketBuffer&&)      = default;
-    ~PacketBuffer() = default;
+    ~PacketBuffer()                   = default;
 
-    void clear() { buffer.clear(); offset = 0; }
+    void clear() {
+        buffer.clear();
+        offset = 0;
+    }
     void resize(const size_t size) { buffer.resize(size); }
     void reserve(const size_t size) { buffer.reserve(size); }
     void append(const ByteVec& data) { buffer.insert(buffer.end(), data.begin(), data.end()); }
     void append(const ByteVec&& data) { buffer.insert(buffer.end(), std::make_move_iterator(data.begin()), std::make_move_iterator(data.end())); }
 
-    bool readBoolean() { return stratos::readBoolean(buffer, offset); }
-    int8_t readByte() { return stratos::readByte(buffer, offset); }
-    uint8_t readUnsignedByte() { return stratos::readUnsignedByte(buffer, offset); }
-    short readShort() { return stratos::readShort(buffer, offset); }
-    uint16_t readUnsignedShort() { return stratos::readUnsignedShort(buffer, offset); }
-    int readInt() { return stratos::readInt(buffer, offset); }
-    int64_t readLong() { return stratos::readLong(buffer, offset); }
-    float readFloat() { return stratos::readFloat(buffer, offset); }
-    double readDouble() { return stratos::readDouble(buffer, offset); }
-    std::string readString(const int maxChars) { return stratos::readString(buffer, offset, maxChars); }
+    bool                  readBoolean() { return stratos::readBoolean(buffer, offset); }
+    int8_t                readByte() { return stratos::readByte(buffer, offset); }
+    uint8_t               readUnsignedByte() { return stratos::readUnsignedByte(buffer, offset); }
+    short                 readShort() { return stratos::readShort(buffer, offset); }
+    uint16_t              readUnsignedShort() { return stratos::readUnsignedShort(buffer, offset); }
+    int                   readInt() { return stratos::readInt(buffer, offset); }
+    int64_t               readLong() { return stratos::readLong(buffer, offset); }
+    float                 readFloat() { return stratos::readFloat(buffer, offset); }
+    double                readDouble() { return stratos::readDouble(buffer, offset); }
+    std::string           readString(const int maxChars) { return stratos::readString(buffer, offset, maxChars); }
+    int                   readVarInt() { return stratos::readVarInt(buffer, offset); }
+    int64_t               readVarLong() { return stratos::readVarLong(buffer, offset); }
+    std::vector<uint64_t> readBitSet() { return stratos::readBitSet(buffer, offset); }
+    std::vector<bool>     readFixedBitSet(const size_t length) { return stratos::readFixedBitSet(buffer, offset, length); }
+    // TODO: Read array of X, optional X, and so on get individual methods per type
+    ByteVec readByteArray(const size_t length) { return stratos::readByteArray(buffer, offset, length); }
 
     void writeBoolean(const bool& value) { stratos::writeBoolean(buffer, value); }
     void writeByte(const int8_t& value) { stratos::writeByte(buffer, value); }
@@ -110,9 +178,13 @@ public:
     void writeLong(const int64_t& value) { stratos::writeLong(buffer, value); }
     void writeFloat(const float& value) { stratos::writeFloat(buffer, value); }
     void writeDouble(const double& value) { stratos::writeDouble(buffer, value); }
-    void writeString(const std::string& value, int maxChars) { stratos::writeString(buffer, value, maxChars); }
-    void writeVarInt(const int& value) { stratos::writeVarInt(buffer, value); }
-    void writeVarLong(const int64_t& value) { stratos::writeVarLong(buffer, value); }
+    void writeString(const std::string& value, const int maxChars) { stratos::writeString(buffer, value, maxChars); }
+    void writeVarInt(int& value) { stratos::writeVarInt(buffer, value); }
+    void writeVarLong(int64_t& value) { stratos::writeVarLong(buffer, value); }
+    void writeBitSet(const std::vector<uint64_t>& longs) { stratos::writeBitSet(buffer, longs); }
+    void writeFixedBitSet(const std::vector<bool>& bits, const size_t length) { stratos::writeFixedBitSet(buffer, bits, length); }
+    // TODO: Write array of X, optional X, and so on get individual methods per type
+    void writeByteArray(const ByteVec& values) { stratos::writeByteArray(buffer, values); }
 
     [[nodiscard]] const ByteVec& getBuffer() const { return buffer; }
     [[nodiscard]] size_t         getOffset() const { return offset; }

--- a/src/network/protocol/PacketSerialization.h
+++ b/src/network/protocol/PacketSerialization.h
@@ -72,6 +72,55 @@ inline bool isReadable(const ByteVec& buffer, const size_t& offset, const size_t
     return true;
 }
 int countUTF16CodeUnits(const std::string& utf8);
+
+class PacketBuffer {
+    ByteVec buffer;
+    size_t offset;
+public:
+    PacketBuffer() : offset(0) {};
+    explicit PacketBuffer(const ByteVec& buffer) : buffer(buffer), offset(0) {};
+    explicit PacketBuffer(ByteVec&& buffer) : buffer(std::move(buffer)), offset(0) {};
+    PacketBuffer(const PacketBuffer&) = default;
+    PacketBuffer(PacketBuffer&&)      = default;
+    ~PacketBuffer() = default;
+
+    void clear() { buffer.clear(); offset = 0; }
+    void resize(const size_t size) { buffer.resize(size); }
+    void reserve(const size_t size) { buffer.reserve(size); }
+    void append(const ByteVec& data) { buffer.insert(buffer.end(), data.begin(), data.end()); }
+    void append(const ByteVec&& data) { buffer.insert(buffer.end(), std::make_move_iterator(data.begin()), std::make_move_iterator(data.end())); }
+
+    bool readBoolean() { return stratos::readBoolean(buffer, offset); }
+    int8_t readByte() { return stratos::readByte(buffer, offset); }
+    uint8_t readUnsignedByte() { return stratos::readUnsignedByte(buffer, offset); }
+    short readShort() { return stratos::readShort(buffer, offset); }
+    uint16_t readUnsignedShort() { return stratos::readUnsignedShort(buffer, offset); }
+    int readInt() { return stratos::readInt(buffer, offset); }
+    int64_t readLong() { return stratos::readLong(buffer, offset); }
+    float readFloat() { return stratos::readFloat(buffer, offset); }
+    double readDouble() { return stratos::readDouble(buffer, offset); }
+    std::string readString(const int maxChars) { return stratos::readString(buffer, offset, maxChars); }
+
+    void writeBoolean(const bool& value) { stratos::writeBoolean(buffer, value); }
+    void writeByte(const int8_t& value) { stratos::writeByte(buffer, value); }
+    void writeUnsignedByte(const uint8_t& value) { stratos::writeUnsignedByte(buffer, value); }
+    void writeShort(const short& value) { stratos::writeShort(buffer, value); }
+    void writeUnsignedShort(const uint16_t& value) { stratos::writeUnsignedShort(buffer, value); }
+    void writeInt(const int& value) { stratos::writeInt(buffer, value); }
+    void writeLong(const int64_t& value) { stratos::writeLong(buffer, value); }
+    void writeFloat(const float& value) { stratos::writeFloat(buffer, value); }
+    void writeDouble(const double& value) { stratos::writeDouble(buffer, value); }
+    void writeString(const std::string& value, int maxChars) { stratos::writeString(buffer, value, maxChars); }
+    void writeVarInt(const int& value) { stratos::writeVarInt(buffer, value); }
+    void writeVarLong(const int64_t& value) { stratos::writeVarLong(buffer, value); }
+
+    [[nodiscard]] const ByteVec& getBuffer() const { return buffer; }
+    [[nodiscard]] size_t         getOffset() const { return offset; }
+    [[nodiscard]] size_t         getSize() const { return buffer.size(); }
+    [[nodiscard]] bool           isEmpty() const { return buffer.empty(); }
+    [[nodiscard]] bool           isReadable() const { return offset < buffer.size(); }
+    [[nodiscard]] bool           isReadable(const size_t& bytes) const { return offset + bytes < buffer.size(); }
+};
 } // namespace stratos
 
 #endif

--- a/test/stratos_test.cpp
+++ b/test/stratos_test.cpp
@@ -1,0 +1,123 @@
+/*
+ *
+ *               _____  _                 _
+ *              /  ___|| |               | |
+ *              \ `--. | |_  _ __   __ _ | |_   ___   ___
+ *               `--. \| __|| '__| / _` || __| / _ \ / __|
+ *              /\__/ /| |_ | |   | (_| || |_ | (_) |\__ \
+ *              \____/  \__||_|    \__,_| \__| \___/ |___/
+ *
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Copyright (C) 2025 Armen Deroian
+ *
+ */
+
+#include "network/protocol/PacketSerialization.h"
+
+#include <cassert>
+#include <iostream>
+#include <ostream>
+#include <string>
+void networkSerializationTest() {
+    std::cout << "Running network serialization test..." << std::endl;
+    stratos::ByteVec buffer;
+    size_t offset = 0;
+
+    // Test writing and reading a boolean
+    std::cout << "Testing boolean serialization..." << std::endl;
+    stratos::writeBoolean(buffer, true);
+    stratos::writeBoolean(buffer, false);
+    assert(stratos::readBoolean(buffer, offset) == true);
+    assert(stratos::readBoolean(buffer, offset) == false);
+
+    // Test writing and reading a byte
+    std::cout << "Testing byte serialization..." << std::endl;
+    stratos::writeByte(buffer, 42);
+    stratos::writeByte(buffer, -42);
+    stratos::writeUnsignedByte(buffer, 230);
+    assert(stratos::readByte(buffer, offset) == 42);
+    assert(stratos::readByte(buffer, offset) == -42);
+    assert(stratos::readUnsignedByte(buffer, offset) == 230);
+
+    // Test writing and reading a short
+    std::cout << "Testing short serialization..." << std::endl;
+    stratos::writeShort(buffer, 12345);
+    stratos::writeShort(buffer, -12345);
+    stratos::writeUnsignedShort(buffer, 54321);
+    assert(stratos::readShort(buffer, offset) == 12345);
+    assert(stratos::readShort(buffer, offset) == -12345);
+    assert(stratos::readUnsignedShort(buffer, offset) == 54321);
+
+    // Test writing and reading an int
+    std::cout << "Testing int serialization..." << std::endl;
+    stratos::writeInt(buffer, 123456789);
+    stratos::writeInt(buffer, -123456789);
+    assert(stratos::readInt(buffer, offset) == 123456789);
+    assert(stratos::readInt(buffer, offset) == -123456789);
+
+    // Test writing and reading a long
+    std::cout << "Testing long serialization..." << std::endl;
+    stratos::writeLong(buffer, 1234567890123456789LL);
+    stratos::writeLong(buffer, -1234567890123456789LL);
+    assert(stratos::readLong(buffer, offset) == 1234567890123456789LL);
+    assert(stratos::readLong(buffer, offset) == -1234567890123456789LL);
+
+    // Test writing and reading a float
+    std::cout << "Testing float serialization..." << std::endl;
+    stratos::writeFloat(buffer, 3.14f);
+    stratos::writeFloat(buffer, -3.14f);
+    assert(stratos::readFloat(buffer, offset) == 3.14f);
+    assert(stratos::readFloat(buffer, offset) == -3.14f);
+
+    // Test writing and reading a double
+    std::cout << "Testing double serialization..." << std::endl;
+    stratos::writeDouble(buffer, 3.141592653589793);
+    stratos::writeDouble(buffer, -3.141592653589793);
+    assert(stratos::readDouble(buffer, offset) == 3.141592653589793);
+    assert(stratos::readDouble(buffer, offset) == -3.141592653589793);
+
+    // Test writing and reading a VarInt
+    std::cout << "Testing VarInt serialization..." << std::endl;
+    stratos::writeVarInt(buffer, 123456);
+    stratos::writeVarInt(buffer, -123456);
+    assert(stratos::readVarInt(buffer, offset) == 123456);
+    assert(stratos::readVarInt(buffer, offset) == -123456);
+
+    // Test writing and reading a string
+    std::cout << "Testing string serialization..." << std::endl;
+    const std::string testString = "Hello, world!";
+    stratos::writeString(buffer, testString, 100);
+    const std::string testString2 = "Another test string with special characters: !@#$%^&*()";
+    stratos::writeString(buffer, testString2, 100);
+    std::string testString3 = "A string with a length that exceeds the maximum allowed length.";
+    try {
+        stratos::writeString(buffer, testString, 10);
+        assert(false); // Should not reach here
+    } catch (const stratos::PacketSerializationException& e) {
+
+    }
+    assert(stratos::readString(buffer, offset, 100) == testString);
+    assert(stratos::readString(buffer, offset, 100) == testString2);
+
+    // Test writing and reading a VarLong
+    std::cout << "Testing VarLong serialization..." << std::endl;
+    stratos::writeVarLong(buffer, 1234567890123456789LL);
+    stratos::writeVarLong(buffer, -1234567890123456789LL);
+    assert(stratos::readVarLong(buffer, offset) == 1234567890123456789LL);
+    assert(stratos::readVarLong(buffer, offset) == -1234567890123456789LL);
+}
+
+int main(const int argc, char **argv) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::string arg = argv[i]; arg == "--network-serialization") {
+            networkSerializationTest();
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- Helper methods for serialization of basic types and some Minecraft basic types.
- PacketBuffer class for handling byte streams for receiving and sending packets.
- Implement status packets as a test.